### PR TITLE
CMake: Fix setting of default build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(sycl-bench)
 
 
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "CMake Build Type" FORCE)
 endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/include)


### PR DESCRIPTION
CMake always creates a cache entry for CMAKE_BUILD_TYPE, even if it's
empty. Variables that are present in the cache should always be updated
rather than *shadowed*.

FORCE is needed to update a cache entry that already exists.

see https://cmake.org/cmake/help/v3.16/command/set.html#set-cache-entry