### PR TITLE
Add option to disable ndrange parallel for kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Benchmarks support the following command line arguments:
 * `--output=<output>` - Specify where to store the output and how to format. If `<output>=stdio`, results are printed to standard output. For any other value, `<output>` is interpreted as a file where the output will be saved in csv format.
 * `--verification-begin=<x,y,z>` - Specify the start of the 3D range that should be used for verifying results. Note: Most benchmarks do not implement this feature. Default: `0,0,0`
 * `--verification-range=<x,y,z>` - Specify the size of the 3D range that should be used for verifying results. Note: Most benchmarks do not implement this feature. Default: `1,1,1`
-
+* `--no-ndrange-kernels` - do not run kernels based on ndrange parallel for

--- a/include/common.h
+++ b/include/common.h
@@ -132,6 +132,11 @@ public:
   const BenchmarkArgs& getArgs() const
   { return args; }
 
+  bool shouldRunNDRangeKernels() const
+  {
+    return !args.cli.isFlagSet("--no-ndrange-kernels");
+  }
+
   template<class Benchmark, typename... AdditionalArgs>
   void run(AdditionalArgs&&... additional_args)
   {

--- a/pattern/reduction.cpp
+++ b/pattern/reduction.cpp
@@ -237,11 +237,12 @@ int main(int argc, char** argv)
   // Using short will lead to overflow even for
   // small problem sizes
   //app.run< ReductionNDRange<short>>();
-  app.run< ReductionNDRange<int>>();
-  app.run< ReductionNDRange<long long>>();
-  app.run< ReductionNDRange<float>>();
-  app.run< ReductionNDRange<double>>();
-
+  if(app.shouldRunNDRangeKernels()){
+    app.run< ReductionNDRange<int>>();
+    app.run< ReductionNDRange<long long>>();
+    app.run< ReductionNDRange<float>>();
+    app.run< ReductionNDRange<double>>();
+  }
   //app.run< ReductionHierarchical<short>>();
   app.run< ReductionHierarchical<int>>();
   app.run< ReductionHierarchical<long long>>();

--- a/pattern/segmentedreduction.cpp
+++ b/pattern/segmentedreduction.cpp
@@ -197,11 +197,13 @@ int main(int argc, char** argv)
 {
   BenchmarkApp app(argc, argv);
 
-  app.run< SegmentedReductionNDRange<short>>();
-  app.run< SegmentedReductionNDRange<int>>();
-  app.run< SegmentedReductionNDRange<long long>>();
-  app.run< SegmentedReductionNDRange<float>>();
-  app.run< SegmentedReductionNDRange<double>>();
+  if(app.shouldRunNDRangeKernels()) {
+    app.run< SegmentedReductionNDRange<short>>();
+    app.run< SegmentedReductionNDRange<int>>();
+    app.run< SegmentedReductionNDRange<long long>>();
+    app.run< SegmentedReductionNDRange<float>>();
+    app.run< SegmentedReductionNDRange<double>>();
+  }
 
   app.run< SegmentedReductionHierarchical<short>>();
   app.run< SegmentedReductionHierarchical<int>>();

--- a/runtime/dag_task_throughput.cpp
+++ b/runtime/dag_task_throughput.cpp
@@ -184,7 +184,8 @@ int main(int argc, char** argv)
   app.run<DagTaskThroughputHierarchicalPF>();
   // With pure CPU library implementations such as hipSYCL CPU backend
   // or triSYCL, this will be prohibitively slow
-  app.run<DagTaskThroughputNDRangePF>();
-  
+  if(app.shouldRunNDRangeKernels())
+    app.run<DagTaskThroughputNDRangePF>();
+
   return 0;
 }

--- a/single-kernel/scalar_prod.cpp
+++ b/single-kernel/scalar_prod.cpp
@@ -194,7 +194,9 @@ public:
 int main(int argc, char** argv)
 {
   BenchmarkApp app(argc, argv);
-  app.run<ScalarProdBench<true>>();
+  if(app.shouldRunNDRangeKernels())
+    app.run<ScalarProdBench<true>>();
+  
   app.run<ScalarProdBench<false>>();
   return 0;
 }


### PR DESCRIPTION
Use `--no-ndrange-kernels` to disable tests with ndrange parallel for as this will be prohibitively slow with triSYCL and hipSYCL CPU backends