### PR TITLE
Fix ComputeCpp compilation errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 if(CMAKE_GENERATOR STREQUAL "Ninja")
   set(CMAKE_SYCL_FLAGS "${CMAKE_SYCL_FLAGS} -fdiagnostics-color=always")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
+  set(COMPUTECPP_USER_FLAGS "${COMPUTECPP_USER_FLAGS} -fdiagnostics-color=always")
 endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/include)

--- a/micro/pattern_shared.cpp
+++ b/micro/pattern_shared.cpp
@@ -34,7 +34,7 @@ public:
       auto out = output_buf.template get_access<s::access::mode::discard_write>(cgh);
       // local memory definition
       s::accessor<DATA_TYPE, 1,s::access::mode::read_write, s::access::target::local> 
-        local_mem(s::range<1>(TILE_DIM), cgh);
+        local_mem(TILE_DIM, cgh);
 
       s::range<1> ndrange {args.problem_size};
 

--- a/pattern/reduction.cpp
+++ b/pattern/reduction.cpp
@@ -93,7 +93,7 @@ private:
     // Retrieve result
     using namespace cl::sycl::access;
     _result = output_buff->template get_access<mode::read>(
-        sycl::range<1>{0}, sycl::range<1>{1})[0];
+        sycl::range<1>{0}, sycl::id<1>{1})[0];
   }
 
   void local_reduce_ndrange(

--- a/polybench/2DConvolution.cpp
+++ b/polybench/2DConvolution.cpp
@@ -10,6 +10,8 @@
 
 using DATA_TYPE = float;
 
+class conv2D;
+
 void init(DATA_TYPE* A, size_t size) {
 	const auto NI = size;
 	const auto NJ = size;

--- a/polybench/2mm.cpp
+++ b/polybench/2mm.cpp
@@ -10,6 +10,9 @@
 
 using DATA_TYPE = float;
 
+class Polybench_2mm_2;
+class Polybench_2mm_1;
+
 void init_array(DATA_TYPE* A, DATA_TYPE* B, DATA_TYPE* C, DATA_TYPE* D, size_t size) {
 	const auto NI = size;
 	const auto NJ = size;
@@ -93,7 +96,7 @@ class Polybench_2mm {
 			auto B = B_buffer.get_access<access::mode::read>(cgh);
 			auto C = C_buffer.get_access<access::mode::read_write>(cgh);
 
-			cgh.parallel_for<class Polybench_2mm_1>(C_buffer.get_range(), [=, size_ = size](item<2> item) {
+			cgh.parallel_for<Polybench_2mm_1>(C_buffer.get_range(), [=, size_ = size](item<2> item) {
 				const auto i = item[0];
 				const auto j = item[1];
 
@@ -108,7 +111,7 @@ class Polybench_2mm {
 			auto D = D_buffer.get_access<access::mode::read>(cgh);
 			auto E = E_buffer.get_access<access::mode::discard_write>(cgh);
 
-			cgh.parallel_for<class Polybench_2mm_2>(E_buffer.get_range(), [=, size_ = size](item<2> item) {
+			cgh.parallel_for<Polybench_2mm_2>(E_buffer.get_range(), [=, size_ = size](item<2> item) {
 				const auto i = item[0];
 				const auto j = item[1];
 

--- a/polybench/3DConvolution.cpp
+++ b/polybench/3DConvolution.cpp
@@ -10,6 +10,8 @@
 
 using DATA_TYPE = float;
 
+class conv3D;
+
 void init(DATA_TYPE* A, size_t size) {
 	const auto NI = size;
 	const auto NJ = size;

--- a/polybench/3mm.cpp
+++ b/polybench/3mm.cpp
@@ -10,6 +10,10 @@
 
 using DATA_TYPE = float;
 
+class Polybench_3mm_1;
+class Polybench_3mm_2;
+class Polybench_3mm_3;
+
 void init_array(DATA_TYPE* A, DATA_TYPE* B, DATA_TYPE* C, DATA_TYPE* D, size_t size) {
 	const auto NI = size;
 	const auto NJ = size;
@@ -112,7 +116,7 @@ class Polybench_3mm {
 			auto B = B_buffer.get_access<access::mode::read>(cgh);
 			auto E = E_buffer.get_access<access::mode::read_write>(cgh);
 
-			cgh.parallel_for<class Polybench_3mm_1>(E_buffer.get_range(), [=, size_ = size](item<2> item) {
+			cgh.parallel_for<Polybench_3mm_1>(E_buffer.get_range(), [=, size_ = size](item<2> item) {
 				const auto i = item[0];
 				const auto j = item[1];
 
@@ -127,7 +131,7 @@ class Polybench_3mm {
 			auto D = D_buffer.get_access<access::mode::read>(cgh);
 			auto F = F_buffer.get_access<access::mode::read_write>(cgh);
 
-			cgh.parallel_for<class Polybench_3mm_2>(F_buffer.get_range(), [=, size_ = size](item<2> item) {
+			cgh.parallel_for<Polybench_3mm_2>(F_buffer.get_range(), [=, size_ = size](item<2> item) {
 				const auto i = item[0];
 				const auto j = item[1];
 
@@ -142,7 +146,7 @@ class Polybench_3mm {
 			auto F = F_buffer.get_access<access::mode::read>(cgh);
 			auto G = G_buffer.get_access<access::mode::read_write>(cgh);
 
-			cgh.parallel_for<class Polybench_3mm_3>(F_buffer.get_range(), [=, size_ = size](item<2> item) {
+			cgh.parallel_for<Polybench_3mm_3>(F_buffer.get_range(), [=, size_ = size](item<2> item) {
 				const auto i = item[0];
 				const auto j = item[1];
 

--- a/polybench/atax.cpp
+++ b/polybench/atax.cpp
@@ -14,6 +14,9 @@
 
 using DATA_TYPE = float;
 
+class Atax1;
+class Atax2;
+
 void init_array(DATA_TYPE* x, DATA_TYPE* A, size_t size) {
 	const auto NX = size;
 	const auto NY = size;
@@ -67,7 +70,7 @@ class Polybench_Atax {
 			auto x = x_buffer.get_access<access::mode::read>(cgh);
 			auto tmp = tmp_buffer.get_access<access::mode::read_write>(cgh);
 
-			cgh.parallel_for<class Atax1>(tmp_buffer.get_range(), [=, size_ = size](item<1> item) {
+			cgh.parallel_for<Atax1>(tmp_buffer.get_range(), [=, size_ = size](item<1> item) {
 				const auto i = item[0];
 
 				for(size_t j = 0; j < size_; j++) {
@@ -81,7 +84,7 @@ class Polybench_Atax {
 			auto y = y_buffer.get_access<access::mode::read_write>(cgh);
 			auto tmp = tmp_buffer.get_access<access::mode::read>(cgh);
 
-			cgh.parallel_for<class Atax2>(y_buffer.get_range(), [=, size_ = size](item<1> item) {
+			cgh.parallel_for<Atax2>(y_buffer.get_range(), [=, size_ = size](item<1> item) {
 				const auto j = item[0];
 
 				for(size_t i = 0; i < size_; i++) {

--- a/polybench/bicg.cpp
+++ b/polybench/bicg.cpp
@@ -14,6 +14,9 @@
 
 using DATA_TYPE = float;
 
+class Bicg1;
+class Bicg2;
+
 void init_array(DATA_TYPE* A, DATA_TYPE* p, DATA_TYPE* r, size_t size) {
 	const auto NX = size;
 	const auto NY = size;
@@ -71,7 +74,7 @@ class Polybench_Bicg {
 			auto r = r_buffer.get_access<access::mode::read>(cgh);
 			auto s = s_buffer.get_access<access::mode::read_write>(cgh);
 
-			cgh.parallel_for<class Bicg1>(s_buffer.get_range(), [=, size_ = size](item<1> item) {
+			cgh.parallel_for<Bicg1>(s_buffer.get_range(), [=, size_ = size](item<1> item) {
 				const auto j = item[0];
 
 				for(size_t i = 0; i < size_; i++) {
@@ -85,7 +88,7 @@ class Polybench_Bicg {
 			auto p = p_buffer.get_access<access::mode::read>(cgh);
 			auto q = q_buffer.get_access<access::mode::read_write>(cgh);
 
-			cgh.parallel_for<class Bicg2>(q_buffer.get_range(), [=, size_ = size](item<1> item) {
+			cgh.parallel_for<Bicg2>(q_buffer.get_range(), [=, size_ = size](item<1> item) {
 				const auto i = item[0];
 
 				for(size_t j = 0; j < size_; j++) {

--- a/polybench/correlation.cpp
+++ b/polybench/correlation.cpp
@@ -16,6 +16,12 @@
 
 using DATA_TYPE = float;
 
+class CorrelationMean;
+class CorrelationStd;
+class CorrelationReduce;
+class CorrelationCorr;
+class Correlation5;
+
 void init_arrays(DATA_TYPE* data, size_t size) {
 	const auto M = size;
 	const auto N = size;
@@ -107,7 +113,7 @@ class Polybench_Correlation {
 			auto data = data_buffer.get_access<access::mode::read>(cgh);
 			auto mean = mean_buffer.get_access<access::mode::read_write>(cgh);
 
-			cgh.parallel_for<class CorrelationMean>(range<1>(size), id<1>(1), [=, N_ = size](item<1> item) {
+			cgh.parallel_for<CorrelationMean>(range<1>(size), id<1>(1), [=, N_ = size](item<1> item) {
 				const auto j = item[0];
 
 				for(size_t i = 1; i <= N_; i++) {
@@ -122,7 +128,7 @@ class Polybench_Correlation {
 			auto mean = mean_buffer.get_access<access::mode::read>(cgh);
 			auto stddev = stddev_buffer.get_access<access::mode::read_write>(cgh);
 
-			cgh.parallel_for<class CorrelationStd>(range<1>(size), id<1>(1), [=, N_ = size](item<1> item) {
+			cgh.parallel_for<CorrelationStd>(range<1>(size), id<1>(1), [=, N_ = size](item<1> item) {
 				const auto j = item[0];
 
 				for(size_t i = 1; i <= N_; i++) {
@@ -140,7 +146,7 @@ class Polybench_Correlation {
 			auto mean = mean_buffer.get_access<access::mode::read>(cgh);
 			auto stddev = stddev_buffer.get_access<access::mode::read>(cgh);
 
-			cgh.parallel_for<class CorrelationReduce>(range<2>(size, size), id<2>(1, 1), [=](item<2> item) {
+			cgh.parallel_for<CorrelationReduce>(range<2>(size, size), id<2>(1, 1), [=](item<2> item) {
 				const auto j = item[1];
 
 				data[item] -= mean[j];
@@ -153,7 +159,7 @@ class Polybench_Correlation {
 			auto data = data_buffer.get_access<access::mode::read>(cgh);
 			auto symmat = symmat_buffer.get_access<access::mode::read_write>(cgh);
 
-			cgh.parallel_for<class CorrelationCorr>(range<1>(size), id<1>(1), [=, M_ = size, N_ = size](item<1> item) {
+			cgh.parallel_for<CorrelationCorr>(range<1>(size), id<1>(1), [=, M_ = size, N_ = size](item<1> item) {
 				// if(item[0] >= M_ - 1) return;
 
 				const auto j1 = item[0];
@@ -174,7 +180,7 @@ class Polybench_Correlation {
 
 		args.device_queue.submit([&](handler& cgh) {
 			auto symmat = symmat_buffer.get_access<access::mode::discard_write>(cgh);
-			cgh.parallel_for<class Correlation5>(range<2>(1, 1), id<2>(size, size), [=](item<2> item) { symmat[item] = 1.0; });
+			cgh.parallel_for<Correlation5>(range<2>(1, 1), id<2>(size, size), [=](item<2> item) { symmat[item] = 1.0; });
 		});
 	}
 

--- a/polybench/covariance.cpp
+++ b/polybench/covariance.cpp
@@ -11,6 +11,10 @@
 
 using DATA_TYPE = float;
 
+class CovarianceMean;
+class CovarianceReduce;
+class CovarianceCovar;
+
 constexpr DATA_TYPE float_n = 3214212.01;
 
 void init_arrays(DATA_TYPE* data, size_t size) {
@@ -79,7 +83,7 @@ class Polybench_Covariance {
 			auto data = data_buffer.get_access<access::mode::read>(cgh);
 			auto mean = mean_buffer.get_access<access::mode::discard_write>(cgh);
 
-			cgh.parallel_for<class CovarianceMean>(range<1>(size), id<1>(1), [=, N_ = size](item<1> item) {
+			cgh.parallel_for<CovarianceMean>(range<1>(size), id<1>(1), [=, N_ = size](item<1> item) {
 				const auto j = item[0];
 
 				mean[item] = 0;
@@ -94,7 +98,7 @@ class Polybench_Covariance {
 			auto mean = mean_buffer.get_access<access::mode::read>(cgh);
 			auto data = data_buffer.get_access<access::mode::read_write>(cgh);
 
-			cgh.parallel_for<class CovarianceReduce>(range<2>(size, size), id<2>(1, 1), [=](item<2> item) {
+			cgh.parallel_for<CovarianceReduce>(range<2>(size, size), id<2>(1, 1), [=](item<2> item) {
 				const auto j = item[1];
 				data[item] -= mean[j];
 			});
@@ -105,7 +109,7 @@ class Polybench_Covariance {
 			auto symmat = symmat_buffer.get_access<access::mode::discard_write>(cgh);
 			auto symmat2 = symmat_buffer.get_access<access::mode::discard_write>(cgh);
 
-			cgh.parallel_for<class CovarianceCovar>(range<1>(size), id<1>(1), [=, M_ = size, N_ = size](item<1> item) {
+			cgh.parallel_for<CovarianceCovar>(range<1>(size), id<1>(1), [=, M_ = size, N_ = size](item<1> item) {
 				const auto j1 = item[0];
 
 				symmat[{j1, j1}] = 1.0;

--- a/polybench/fdtd2d.cpp
+++ b/polybench/fdtd2d.cpp
@@ -10,6 +10,10 @@
 
 using DATA_TYPE = double;
 
+class Fdtd2d1;
+class Fdtd2d2;
+class Fdtd2d3;
+
 constexpr auto TMAX = 500;
 
 void init_arrays(DATA_TYPE* fict, DATA_TYPE* ex, DATA_TYPE* ey, DATA_TYPE* hz, size_t size) {
@@ -85,7 +89,7 @@ class Polybench_Fdtd2d {
 				auto ey = ey_buffer.get_access<access::mode::read_write>(cgh);
 				auto hz = hz_buffer.get_access<access::mode::read>(cgh);
 
-				cgh.parallel_for<class Fdtd2d1>(range<2>(size, size), [=](item<2> item) {
+				cgh.parallel_for<Fdtd2d1>(range<2>(size, size), [=](item<2> item) {
 					const auto i = item[0];
 					const auto j = item[1];
 
@@ -101,7 +105,7 @@ class Polybench_Fdtd2d {
 				auto ex = ex_buffer.get_access<access::mode::read_write>(cgh);
 				auto hz = hz_buffer.get_access<access::mode::read>(cgh);
 
-				cgh.parallel_for<class Fdtd2d2>(range<2>(size, size), [=, NX_ = size, NY_ = size](item<2> item) {
+				cgh.parallel_for<Fdtd2d2>(range<2>(size, size), [=, NX_ = size, NY_ = size](item<2> item) {
 					const auto i = item[0];
 					const auto j = item[1];
 
@@ -114,7 +118,7 @@ class Polybench_Fdtd2d {
 				auto ey = ey_buffer.get_access<access::mode::read>(cgh);
 				auto hz = hz_buffer.get_access<access::mode::read_write>(cgh);
 
-				cgh.parallel_for<class Fdtd2d3>(hz_buffer.get_range(), [=](item<2> item) {
+				cgh.parallel_for<Fdtd2d3>(hz_buffer.get_range(), [=](item<2> item) {
 					const auto i = item[0];
 					const auto j = item[1];
 

--- a/polybench/gemm.cpp
+++ b/polybench/gemm.cpp
@@ -13,6 +13,8 @@
 
 using DATA_TYPE = float;
 
+class Gemm;
+
 void init(DATA_TYPE* A, DATA_TYPE* B, DATA_TYPE* C, size_t size) {
 	const auto NI = size;
 	const auto NJ = size;
@@ -77,7 +79,7 @@ class Polybench_Gemm {
 			auto B = B_buffer.get_access<access::mode::read>(cgh);
 			auto C = C_buffer.get_access<access::mode::read_write>(cgh);
 
-			cgh.parallel_for<class Gemm>(C_buffer.get_range(), [=, NK_ = size](item<2> item) {
+			cgh.parallel_for<Gemm>(C_buffer.get_range(), [=, NK_ = size](item<2> item) {
 				const auto i = item[0];
 				const auto j = item[1];
 

--- a/polybench/gesummv.cpp
+++ b/polybench/gesummv.cpp
@@ -10,6 +10,8 @@
 
 using DATA_TYPE = float;
 
+class Gesummv;
+
 constexpr DATA_TYPE ALPHA = 1;
 constexpr DATA_TYPE BETA = 1;
 
@@ -82,7 +84,7 @@ class Polybench_Gesummv {
 			auto y = y_buffer.get_access<access::mode::read_write>(cgh);
 			auto tmp = tmp_buffer.get_access<access::mode::read_write>(cgh);
 
-			cgh.parallel_for<class Gesummv>(y.get_range(), [=, N_ = size](item<1> item) {
+			cgh.parallel_for<Gesummv>(y.get_range(), [=, N_ = size](item<1> item) {
 				const auto i = item[0];
 
 				for(size_t j = 0; j < N_; j++) {

--- a/polybench/gramschmidt.cpp
+++ b/polybench/gramschmidt.cpp
@@ -11,6 +11,10 @@
 
 using DATA_TYPE = float;
 
+class Gramschmidt1;
+class Gramschmidt2;
+class Gramschmidt3;
+
 void init_array(DATA_TYPE* A, size_t size) {
 	const auto M = 0;
 	const auto N = 0;
@@ -73,7 +77,7 @@ class Polybench_Gramschmidt {
 				auto A = A_buffer.get_access<access::mode::read>(cgh);
 				auto R = R_buffer.get_access<access::mode::write>(cgh);
 
-				cgh.parallel_for<class Gramschmidt1>(range<2>(1, 1), [=, M_ = size](item<2> item) {
+				cgh.parallel_for<Gramschmidt1>(range<2>(1, 1), [=, M_ = size](item<2> item) {
 					DATA_TYPE nrm = 0;
 					for(size_t i = 0; i < M_; i++) {
 						nrm += A[{i, k}] * A[{i, k}];
@@ -87,7 +91,7 @@ class Polybench_Gramschmidt {
 				auto R = R_buffer.get_access<access::mode::read>(cgh);
 				auto Q = Q_buffer.get_access<access::mode::write>(cgh);
 
-				cgh.parallel_for<class Gramschmidt2>(range<2>(size, 1), id<2>(0, k), [=](item<2> item) { Q[item] = A[item] / R[{k, k}]; });
+				cgh.parallel_for<Gramschmidt2>(range<2>(size, 1), id<2>(0, k), [=](item<2> item) { Q[item] = A[item] / R[{k, k}]; });
 			});
 
 			args.device_queue.submit([&](handler& cgh) {
@@ -95,7 +99,7 @@ class Polybench_Gramschmidt {
 				auto R = R_buffer.get_access<access::mode::write>(cgh);
 				auto Q = Q_buffer.get_access<access::mode::read>(cgh);
 
-				cgh.parallel_for<class Gramschmidt3>(range<2>(size, 1), [=, M_ = size, N_ = size](item<2> item) {
+				cgh.parallel_for<Gramschmidt3>(range<2>(size, 1), [=, M_ = size, N_ = size](item<2> item) {
 					const auto j = item[0];
 
 					if(j <= k || j >= N_) return;

--- a/polybench/mvt.cpp
+++ b/polybench/mvt.cpp
@@ -10,6 +10,9 @@
 
 using DATA_TYPE = float;
 
+class Mvt1;
+class Mvt2;
+
 void init_arrays(DATA_TYPE* a, DATA_TYPE* x1, DATA_TYPE* x2, DATA_TYPE* y_1, DATA_TYPE* y_2, size_t size) {
 	const auto N = size;
 
@@ -69,7 +72,7 @@ class Polybench_Mvt {
 			auto y1 = y1_buffer.get_access<access::mode::read>(cgh);
 			auto x1 = x1_buffer.get_access<access::mode::read_write>(cgh);
 
-			cgh.parallel_for<class Mvt1>(x1_buffer.get_range(), [=, N_ = size](item<1> item) {
+			cgh.parallel_for<Mvt1>(x1_buffer.get_range(), [=, N_ = size](item<1> item) {
 				const auto i = item[0];
 
 				for(size_t j = 0; j < N_; j++) {
@@ -83,7 +86,7 @@ class Polybench_Mvt {
 			auto y2 = y2_buffer.get_access<access::mode::read>(cgh);
 			auto x2 = x2_buffer.get_access<access::mode::read_write>(cgh);
 
-			cgh.parallel_for<class Mvt2>(x1_buffer.get_range(), [=, N_ = size](item<1> item) {
+			cgh.parallel_for<Mvt2>(x1_buffer.get_range(), [=, N_ = size](item<1> item) {
 				const auto k = item[0];
 
 				for(size_t l = 0; l < N_; l++) {

--- a/polybench/syr2k.cpp
+++ b/polybench/syr2k.cpp
@@ -10,6 +10,8 @@
 
 using DATA_TYPE = float;
 
+class Syr2k1;
+
 constexpr DATA_TYPE ALPHA = 1;
 constexpr DATA_TYPE BETA = 1;
 
@@ -73,7 +75,7 @@ class Polybench_Syr2k {
 			auto B = B_buffer.get_access<access::mode::read>(cgh);
 			auto C = C_buffer.get_access<access::mode::read_write>(cgh);
 
-			cgh.parallel_for<class Syr2k1>(C_buffer.get_range(), [=, M_ = size](item<2> item) {
+			cgh.parallel_for<Syr2k1>(C_buffer.get_range(), [=, M_ = size](item<2> item) {
 				const auto i = item[0];
 				const auto j = item[1];
 

--- a/polybench/syrk.cpp
+++ b/polybench/syrk.cpp
@@ -10,6 +10,8 @@
 
 using DATA_TYPE = float;
 
+class Syr2k2;
+
 constexpr DATA_TYPE alpha = 123;
 constexpr DATA_TYPE beta = 14512;
 
@@ -69,7 +71,7 @@ class Polybench_Syrk {
 			auto A = A_buffer.get_access<access::mode::read>(cgh);
 			auto C = C_buffer.get_access<access::mode::read_write>(cgh);
 
-			cgh.parallel_for<class Syr2k2>(C_buffer.get_range(), [=, M_ = size](item<2> item) {
+			cgh.parallel_for<Syr2k2>(C_buffer.get_range(), [=, M_ = size](item<2> item) {
 				const auto i = item[0];
 				const auto j = item[1];
 

--- a/runtime/dag_task_throughput_independent.cpp
+++ b/runtime/dag_task_throughput_independent.cpp
@@ -4,6 +4,11 @@
 
 using namespace cl;
 
+class IndependentDagTaskThroughputKernelSingleTask;
+class IndependentDagTaskThroughputKernelBasicPF;
+class DagTaskThroughputKernelNdrangePF;
+class DagTaskThroughputKernelHierarchicalPF;
+
 // Measures the time it takes to run <problem-size> trivial single_task and parallel_for kernels
 // that are *independent*. 
 // This benchmark can be used to see how well a SYCL implementation
@@ -32,7 +37,7 @@ public:
           [&](cl::sycl::handler& cgh) {
         auto acc = dummy_buffers[i].get_access<sycl::access::mode::discard_write>(cgh);
         
-        cgh.single_task<class IndependentDagTaskThroughputKernelSingleTask>(
+        cgh.single_task<IndependentDagTaskThroughputKernelSingleTask>(
           [=]()
         {
           acc[0] = i;
@@ -48,7 +53,7 @@ public:
           [&](cl::sycl::handler& cgh) {
         auto acc = dummy_buffers[i].get_access<sycl::access::mode::discard_write>(cgh);
         
-        cgh.parallel_for<class IndependentDagTaskThroughputKernelBasicPF>(
+        cgh.parallel_for<IndependentDagTaskThroughputKernelBasicPF>(
           
           sycl::range<1>{args.local_size},
           [=](sycl::id<1> idx)
@@ -67,7 +72,7 @@ public:
           [&](cl::sycl::handler& cgh) {
         auto acc = dummy_buffers[i].get_access<sycl::access::mode::discard_write>(cgh);
         
-        cgh.parallel_for<class DagTaskThroughputKernelNdrangePF>(
+        cgh.parallel_for<DagTaskThroughputKernelNdrangePF>(
           sycl::nd_range<1>{
             sycl::range<1>{args.local_size},
             sycl::range<1>{args.local_size}},
@@ -87,7 +92,7 @@ public:
           [&](cl::sycl::handler& cgh) {
         auto acc = dummy_buffers[i].get_access<sycl::access::mode::discard_write>(cgh);
         
-        cgh.parallel_for_work_group<class DagTaskThroughputKernelHierarchicalPF>(
+        cgh.parallel_for_work_group<DagTaskThroughputKernelHierarchicalPF>(
           sycl::range<1>{1}, sycl::range<1>{args.local_size},
           [=](sycl::group<1> grp)
         {

--- a/runtime/dag_task_throughput_sequential.cpp
+++ b/runtime/dag_task_throughput_sequential.cpp
@@ -2,6 +2,11 @@
 
 using namespace cl;
 
+class DagTaskThroughputKernelSingleTask;
+class DagTaskThroughputKernelBasicPF;
+class DagTaskThroughputKernelNdrangePF;
+class DagTaskThroughputKernelHierarchicalPF;
+
 // Measures the time it takes to run <problem-size> trivial single_task and parallel_for kernels
 // that depend on each other, and have to be executed in-order (-> Utilization of
 // parallel hardware is *not* tested)
@@ -33,7 +38,7 @@ public:
           [&](cl::sycl::handler& cgh) {
         auto acc = dummy_counter.get_access<sycl::access::mode::read_write>(cgh);
         
-        cgh.single_task<class DagTaskThroughputKernelSingleTask>(
+        cgh.single_task<DagTaskThroughputKernelSingleTask>(
           [=]()
         {
           acc[0] += 1;
@@ -49,7 +54,7 @@ public:
           [&](cl::sycl::handler& cgh) {
         auto acc = dummy_counter.get_access<sycl::access::mode::read_write>(cgh);
         
-        cgh.parallel_for<class DagTaskThroughputKernelBasicPF>(
+        cgh.parallel_for<DagTaskThroughputKernelBasicPF>(
           // while we cannot control it, let's hope the SYCL implementation 
           // spawns a single work group.
           sycl::range<1>{args.local_size},
@@ -69,7 +74,7 @@ public:
           [&](cl::sycl::handler& cgh) {
         auto acc = dummy_counter.get_access<sycl::access::mode::read_write>(cgh);
         
-        cgh.parallel_for<class DagTaskThroughputKernelNdrangePF>(
+        cgh.parallel_for<DagTaskThroughputKernelNdrangePF>(
           sycl::nd_range<1>{
             sycl::range<1>{args.local_size},
             sycl::range<1>{args.local_size}},
@@ -89,7 +94,7 @@ public:
           [&](cl::sycl::handler& cgh) {
         auto acc = dummy_counter.get_access<sycl::access::mode::read_write>(cgh);
         
-        cgh.parallel_for_work_group<class DagTaskThroughputKernelHierarchicalPF>(
+        cgh.parallel_for_work_group<DagTaskThroughputKernelHierarchicalPF>(
           sycl::range<1>{1}, sycl::range<1>{args.local_size},
           [=](sycl::group<1> grp)
         {

--- a/single-kernel/kmeans.cpp
+++ b/single-kernel/kmeans.cpp
@@ -52,17 +52,19 @@ public:
       cl::sycl::range<1> ndrange (args.problem_size);
 
       cgh.parallel_for<class KmeansKernel<T>>(ndrange,
-        [=](cl::sycl::id<1> idx) 
+        [features, clusters, membership, problem_size = args.problem_size,
+         nclusters_ = nclusters, nfeatures_ = nfeatures]
+        (cl::sycl::id<1> idx)
         {
             size_t gid= idx[0];
 
-            if (gid < args.problem_size) {
+            if (gid < problem_size) {
                 int index = 0;
                 T min_dist = FLT_MAX;
-                for (size_t i = 0; i < nclusters; i++) {
+                for (size_t i = 0; i < nclusters_; i++) {
                     T dist = 0;
-                    for (size_t l = 0; l < nfeatures; l++) {
-                        dist += (features[l * args.problem_size + gid] - clusters[i * nfeatures + l]) * (features[l * args.problem_size + gid] - clusters[i * nfeatures + l]);
+                    for (size_t l = 0; l < nfeatures_; l++) {
+                        dist += (features[l * problem_size + gid] - clusters[i * nfeatures_ + l]) * (features[l * problem_size + gid] - clusters[i * nfeatures_ + l]);
 		            }
                     if (dist < min_dist) {
                         min_dist = dist;

--- a/single-kernel/lin_reg.cpp
+++ b/single-kernel/lin_reg.cpp
@@ -56,15 +56,15 @@ public:
       cl::sycl::range<1> ndrange (args.problem_size);
 
       cgh.parallel_for<class LinearRegressionKernel<T>>(ndrange,
-        [=](cl::sycl::id<1> idx) 
+        [=, problem_size = args.problem_size](cl::sycl::id<1> idx)
         {
           size_t gid= idx[0];
           T a = alpha[gid];
           T b = beta[gid];
           T error = 0.0;
-          if (gid < args.problem_size) {
+          if (gid < problem_size) {
               // Use parallel reduction to add errors
-              for (size_t i = 0; i < args.problem_size; i++) {
+              for (size_t i = 0; i < problem_size; i++) {
                 T e = (a*in1[i] + b) - in2[i];
                 error += e*e;
               }

--- a/single-kernel/sobel.cpp
+++ b/single-kernel/sobel.cpp
@@ -50,7 +50,7 @@ public:
       };
 
       cgh.parallel_for<class SobelBenchKernel>(ndrange,
-        [=](cl::sycl::id<2> gid) 
+        [in, out, kernel, size_ = size](cl::sycl::id<2> gid)
         {
           int x = gid[0];
           int y = gid[1];
@@ -69,7 +69,7 @@ public:
               // for the same pixel, convolution is always 0  
               if(x==xs && y==ys) continue; 
               // boundary check
-              if(xs < 0 || xs >= size || ys < 0 || ys >= size) continue;
+              if(xs < 0 || xs >= size_ || ys < 0 || ys >= size_) continue;
                     
 	            // sample color
               cl::sycl::float4 sample = in[ {xs,ys} ];

--- a/single-kernel/sobel5.cpp
+++ b/single-kernel/sobel5.cpp
@@ -6,7 +6,7 @@
 
 
 namespace s = cl::sycl;
-class SobelBenchKernel; // kernel forward declaration
+class Sobel5BenchKernel; // kernel forward declaration
 
 
 /*
@@ -54,8 +54,8 @@ public:
 	      1,  2, 0,  -2, -1
       };
 
-      cgh.parallel_for<class Sobel5BenchKernel>(ndrange,
-        [=](cl::sycl::id<2> gid)
+      cgh.parallel_for<Sobel5BenchKernel>(ndrange,
+        [in, out, kernel, size_ = size](cl::sycl::id<2> gid)
         {
           int x = gid[0];
           int y = gid[1];
@@ -74,7 +74,7 @@ public:
               // for the same pixel, convolution is always 0  
               if(x==xs && y==ys) continue;
               // boundary check
-              if(xs < 0 || xs >= size || ys < 0 || ys >= size) continue;
+              if(xs < 0 || xs >= size_ || ys < 0 || ys >= size_) continue;
 
               // sample color
               cl::sycl::float4 sample = in[ {xs,ys} ];

--- a/single-kernel/sobel7.cpp
+++ b/single-kernel/sobel7.cpp
@@ -6,7 +6,7 @@
 
 
 namespace s = cl::sycl;
-class SobelBenchKernel; // kernel forward declaration
+class Sobel7BenchKernel; // kernel forward declaration
 
 
 /*
@@ -54,8 +54,8 @@ public:
 	      130, 120, 78,  0, -78,  -120, -130
       };
 
-      cgh.parallel_for<class Sobel7BenchKernel>(ndrange,
-        [=](cl::sycl::id<2> gid)
+      cgh.parallel_for<Sobel7BenchKernel>(ndrange,
+        [in, out, kernel, size_ = size](cl::sycl::id<2> gid)
         {
           int x = gid[0];
           int y = gid[1];
@@ -74,7 +74,7 @@ public:
               // for the same pixel, convolution is always 0  
               if(x==xs && y==ys) continue;
               // boundary check
-              if(xs < 0 || xs >= size || ys < 0 || ys >= size) continue;
+              if(xs < 0 || xs >= size_ || ys < 0 || ys >= size_) continue;
 
               // sample color
               cl::sycl::float4 sample = in[ {xs,ys} ];


### PR DESCRIPTION
With these changes, I can now successfully compile all benchmarks using ComputeCpp 1.2.0. The issues were mostly related to kernels implicitly capturing `this` (which is not allowed). This also fixes some warnings for locally declared kernel names (by moving the forward declaration to global scope).

Note that not all benchmarks appear to work correctly for me at the moment. Specifically, I get a segfault for `reduction` and the verification fails for polybench's `correlation`. However these might be due to me using the experimental PTX backend.