### PR TITLE
Allow benchmarks to not implement verify()

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -7,6 +7,8 @@
 #include <sstream>
 #include <memory>
 #include <algorithm> // for std::min
+#include <type_traits>
+
 #include "command_line.h"
 #include "result_consumer.h"
 #include "type_traits.h"
@@ -19,7 +21,19 @@
   #include "nv_energy_meas.h"
 #endif
 
+namespace detail {
 
+template <typename T, typename = void>
+struct VerificationDispatcher {
+  static constexpr bool canVerify = false;
+};
+
+template <typename T>
+struct VerificationDispatcher<T, std::void_t<decltype(&T::verify)>> {
+  static constexpr bool canVerify = true;
+};
+
+} // namespace detail
 
 template<class Benchmark>
 class BenchmarkManager
@@ -70,12 +84,15 @@ public:
       args.device_queue.wait_and_throw();
       for (auto h : hooks) h->postKernel();
 
-      if(args.verification.range.size() > 0)
-        if(args.verification.enabled){
-          if(!b.verify(args.verification)) {
-            all_runs_pass = false;
+      if constexpr(detail::VerificationDispatcher<Benchmark>::canVerify) {
+        if(args.verification.range.size() > 0) {
+          if(args.verification.enabled) {
+            if(!b.verify(args.verification)) {
+              all_runs_pass = false;
+            }
           }
         }
+      }
     }
 
     for (auto h : hooks) {
@@ -83,8 +100,9 @@ public:
       h->emitResults(*args.result_consumer);
     }
 
-    if(args.verification.range.size() == 0 || !args.verification.enabled){
-      args.result_consumer->consumeResult("Verification", "--/--");
+    if(args.verification.range.size() == 0 || !args.verification.enabled ||
+        !detail::VerificationDispatcher<Benchmark>::canVerify) {
+      args.result_consumer->consumeResult("Verification", "N/A");
     }
     else if(!all_runs_pass){
       // error

--- a/micro/pattern_L2.cpp
+++ b/micro/pattern_L2.cpp
@@ -48,12 +48,6 @@ public:
     args.device_queue.wait_and_throw();
   }
 
-  bool verify(VerificationSetting &ver) {
-    bool pass = true;
-    std::cout << "No verification available" << std::endl;
-    return pass;
-  }
-
   static std::string getBenchmarkName() {
     std::stringstream name;
     name << "MicroBench_L2_";

--- a/micro/pattern_arith.cpp
+++ b/micro/pattern_arith.cpp
@@ -52,12 +52,6 @@ public:
     args.device_queue.wait_and_throw();
   }
 
-  bool verify(VerificationSetting &ver) { 
-    bool pass = true;
-    std::cout << "No verification available" << std::endl;
-    return pass;
-  }
-  
   static std::string getBenchmarkName() {
     std::stringstream name;
     name << "MicroBench_Arith_";

--- a/micro/pattern_sf.cpp
+++ b/micro/pattern_sf.cpp
@@ -52,12 +52,6 @@ public:
     args.device_queue.wait_and_throw();
   }
 
-  bool verify(VerificationSetting &ver) {
-    bool pass = true;
-    std::cout << "No verification available" << std::endl;
-    return pass;
-  }
-
   static std::string getBenchmarkName() {
     std::stringstream name;
     name << "MicroBench_sf_";

--- a/micro/pattern_shared.cpp
+++ b/micro/pattern_shared.cpp
@@ -53,12 +53,6 @@ public:
     args.device_queue.wait_and_throw();
   }
 
-  bool verify(VerificationSetting &ver) {
-    bool pass = true;
-    std::cout << "No verification available" << std::endl;
-    return pass;
-  }
-
   static std::string getBenchmarkName() {
     std::stringstream name;
     name << "MicroBench_Shared_";


### PR DESCRIPTION
This extends the BenchmarkManager to make use of SFINAE to dispatch calls to `verify()` only if the function is implemented on a given benchmark.

If not implemented, instead of simply reporting "PASS", verification will now be properly indicated as not available ("N/A") in the generated output.