### PR TITLE
Install benchmarks to subdirectory bin/benchmarks instead of bin/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ foreach(benchmark IN LISTS benchmarks)
     add_sycl_to_target(TARGET ${target} SOURCES ${benchmark})
   endif()
 
-  install(TARGETS ${target} RUNTIME DESTINATION bin/)
+  install(TARGETS ${target} RUNTIME DESTINATION bin/benchmarks/)
   get_filename_component(dir ${benchmark} DIRECTORY)
   set_property(TARGET ${target} PROPERTY FOLDER ${dir})
 endforeach(benchmark)

--- a/bin/run-suite
+++ b/bin/run-suite
@@ -95,10 +95,7 @@ def invoke_benchmark(benchmark_executable, args):
   return retcode, elapsed_time
 
 def is_benchmark(filepath):
-  # Don't execute this script again
-  if filepath == os.path.realpath(__file__):
-    return False
-  
+
   filename, extension = os.path.splitext(filepath)
 
   # Yeah, so this is a bit of a hack.. the better solution would be
@@ -111,7 +108,7 @@ def is_benchmark(filepath):
   return True
 
 if __name__ == '__main__':
-  install_dir = os.path.dirname(os.path.realpath(__file__))
+  install_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)),"benchmarks")
 
   profilename = 'default'
 
@@ -146,7 +143,7 @@ if __name__ == '__main__':
   for root, dirs, files in os.walk(install_dir):
     for filename in files:
       benchmark_name = filename
-      benchmark_executable = os.path.realpath(filename)
+      benchmark_executable = os.path.realpath(os.path.join(install_dir,filename))
       if is_benchmark(benchmark_executable):
         
         print("\n\n##################################################")

--- a/single-kernel/median.cpp
+++ b/single-kernel/median.cpp
@@ -38,7 +38,7 @@ public:
   void setup() {
     size = args.problem_size; // input size defined by the user
     input.resize(size * size); 
-    load_bitmap_mirrored("../share/Brommy.bmp", size, input);
+    load_bitmap_mirrored("../../share/Brommy.bmp", size, input);
     output.resize(size * size);
   }
 

--- a/single-kernel/sobel.cpp
+++ b/single-kernel/sobel.cpp
@@ -28,7 +28,7 @@ public:
   void setup() {
     size = args.problem_size; // input size defined by the user
     input.resize(size * size); 
-    load_bitmap_mirrored("../share/Brommy.bmp", size, input);
+    load_bitmap_mirrored("../../share/Brommy.bmp", size, input);
     output.resize(size * size);
   }
 

--- a/single-kernel/sobel5.cpp
+++ b/single-kernel/sobel5.cpp
@@ -31,7 +31,7 @@ public:
   void setup() {
     size = args.problem_size; // input size defined by the user
     input.resize(size * size);
-    load_bitmap_mirrored("../share/Brommy.bmp", size, input);
+    load_bitmap_mirrored("../../share/Brommy.bmp", size, input);
     output.resize(size * size);
   }
 

--- a/single-kernel/sobel7.cpp
+++ b/single-kernel/sobel7.cpp
@@ -29,7 +29,7 @@ public:
   void setup() {
     size = args.problem_size; // input size defined by the user
     input.resize(size * size);
-    load_bitmap_mirrored("../share/Brommy.bmp", size, input);
+    load_bitmap_mirrored("../../share/Brommy.bmp", size, input);
     output.resize(size * size);
   }
 


### PR DESCRIPTION
This installs benchmarks to subdirectory bin/benchmarks instead of bin/. Very likely fixes some reported cases of the `run-suite` script trying to run itself as a benchmark. Also makes the directory layout clearer, emphasizing the role of the `run-suite` script as master program to run all the benchmarks:
```
bin/
  run-suite
  benchmarks/
    benchmark0
    benchmark1
    benchmark2
    ...
```