### PR TITLE
Add generic throughput metric

### DIFF
--- a/include/benchmark_traits.h
+++ b/include/benchmark_traits.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace detail {
+
+#define MAKE_HAS_METHOD_TRAIT(T, method, name)                                                                         \
+  template <typename _T>                                                                                               \
+  static constexpr std::false_type _has_##method(...);                                                                 \
+  template <typename _T>                                                                                               \
+  static constexpr std::true_type _has_##method(_T, decltype(&_T::method) = nullptr);                                  \
+  static constexpr bool name = std::is_same_v<decltype(_has_##method<T>(std::declval<T>())), std::true_type>;
+
+template <typename T>
+struct BenchmarkTraits {
+  MAKE_HAS_METHOD_TRAIT(T, verify, hasVerify)
+  MAKE_HAS_METHOD_TRAIT(T, getThroughputMetric, hasGetThroughputMetric)
+};
+
+} // namespace detail

--- a/include/result_consumer.h
+++ b/include/result_consumer.h
@@ -15,7 +15,7 @@ public:
   // Register a result in the result consumer
   virtual void consumeResult(const std::string& result_name,
                             const std::string& result,
-                            const std::string& comment = std::string{}) = 0;
+                            const std::string& unit = "") = 0;
 
   // Guarantees that the results have been emitted to the output
   // as specified by the ResultConsumer implementation
@@ -45,11 +45,12 @@ public:
 
   virtual void consumeResult(const std::string& result_name,
                             const std::string& result,
-                            const std::string& comment = std::string{}) override
+                            const std::string& unit = "") override
   {
     output << result_name << ": " << result;
-    if(comment.length() > 0)
-      output << " Note: " << comment;
+    if(!unit.empty()) {
+      output << " [" << unit << "]";
+    }
     output << std::endl;
   }
 
@@ -75,7 +76,7 @@ public:
 
   virtual void consumeResult(const std::string& result_name,
                             const std::string& result,
-                            const std::string& comment = std::string{}) override
+                            const std::string& unit = "") override
   {
     data[currentBenchmark][result_name] = result;
   }

--- a/include/time_meas.h
+++ b/include/time_meas.h
@@ -1,71 +1,107 @@
-#pragma once 
+#pragma once
 
-// time measurement
-#include "benchmark_hook.h"
-
-#include <iostream>
 #include <chrono>
+#include <cmath>
+#include <iostream>
+#include <numeric>
 #include <string>
 #include <vector>
-#include <numeric>
-#include <cmath>
 
-typedef std::chrono::high_resolution_clock Clock;
+#include "benchmark_hook.h"
+#include "benchmark_traits.h"
+#include "command_line.h"
+#include "result_consumer.h"
 
-class TimeMeasurement : public BenchmarkHook
-{
-private:
-    std::chrono::time_point<std::chrono::high_resolution_clock>  t1;
-    std::chrono::time_point<std::chrono::high_resolution_clock>  t2;
+/**
+ * Throughput metrics can be returned by benchmarks that implement the
+ * getThroughputMetric() function. The returned value (and associated unit)
+ * represents the metric underlying the throughput calculation associated with
+ * a benchmark.
+ *
+ * Note that the metric is NOT the throughput. For example, a returned metric
+ * for arithmetric throughput could be the total number of floating-point operations,
+ * FLOP, not FLOP/s.
+ */
+struct ThroughputMetric {
+  double metric = 0.0;
+  std::string unit = "";
+};
 
-    std::vector<double> seconds;
+
+template <typename Benchmark>
+class TimeMeasurement : public BenchmarkHook {
+  using Clock = std::chrono::high_resolution_clock;
+
 public:
-    TimeMeasurement() : BenchmarkHook() {}
-    
-    virtual void atInit() override {}    
-    virtual void preSetup() override {} 
-    virtual void postSetup() override {}
+  TimeMeasurement(const BenchmarkArgs& args) : BenchmarkHook(), args(args) {}
 
-    virtual void preKernel() override {
-        t1 = Clock::now();
+  virtual void atInit() override {}
+  virtual void preSetup() override {}
+  virtual void postSetup() override {}
+
+  virtual void preKernel() override { t1 = Clock::now(); }
+
+  virtual void postKernel() override {
+    t2 = Clock::now();
+    seconds.push_back(
+        static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count()) * 1.e-9);
+  }
+
+  virtual void emitResults(ResultConsumer& consumer) override {
+    std::string full_result_string = "\"";
+    for(auto s : seconds) {
+      full_result_string += std::to_string(s);
+      full_result_string += " ";
+    }
+    full_result_string += "\"";
+
+    double mean_sec = std::accumulate(seconds.begin(), seconds.end(), 0.) / static_cast<double>(seconds.size());
+
+    double stddev = 0.0;
+    for(double x : seconds) {
+      double dev = mean_sec - x;
+      stddev += dev * dev;
+    }
+    if(seconds.size() <= 1)
+      stddev = 0.0;
+    else {
+      stddev /= static_cast<double>(seconds.size() - 1);
+      stddev = std::sqrt(stddev);
     }
 
-    virtual void postKernel() override {
-        t2 = Clock::now();
-        seconds.push_back( 
-            static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count())
-            * 1.e-9);    
+    std::sort(seconds.begin(), seconds.end());
+    const double median_sec = seconds[seconds.size() / 2];
+
+    consumer.consumeResult("run-time", std::to_string(mean_sec), "s");
+    consumer.consumeResult("run-time-stddev", std::to_string(stddev), "s");
+    consumer.consumeResult("run-time-median", std::to_string(median_sec), "s");
+    consumer.consumeResult("run-time-min", std::to_string(seconds[0]), "s");
+    consumer.consumeResult("run-time-samples", full_result_string);
+
+    double throughputMetric = 0.0;
+    double throughput = 0.0;
+    std::string unit = "";
+    if constexpr(detail::BenchmarkTraits<Benchmark>::hasGetThroughputMetric) {
+      const double min_sec = seconds[0];
+      const auto tpm = Benchmark::getThroughputMetric(args);
+      throughputMetric = tpm.metric;
+      throughput = throughputMetric / min_sec;
+      unit = tpm.unit;
     }
-
-    virtual void emitResults(ResultConsumer& consumer) override {
-
-        std::string full_result_string = "\"";
-        for(auto s : seconds) {
-          full_result_string += std::to_string(s);
-          full_result_string += " ";
-        }
-        full_result_string += "\"";
-      
-        double mean_sec = std::accumulate(seconds.begin(), seconds.end(), 0.)
-                        / static_cast<double>(seconds.size());
-
-        double stddev = 0.0;
-        for(double x : seconds)
-        {
-            double dev = mean_sec - x;
-            stddev += dev*dev;
-        }
-        if(seconds.size() <= 1)
-            stddev = 0.0;
-        else {
-            stddev /= static_cast<double>(seconds.size()-1);
-            stddev = std::sqrt(stddev);
-        }
-
-        consumer.consumeResult("run-time", 
-            std::to_string(mean_sec), 
-            " [s]");
-        consumer.consumeResult("run-time-stddev", std::to_string(stddev), " [s]");
-        consumer.consumeResult("run-time-samples", full_result_string);
+    if(throughputMetric > 0.0) {
+      consumer.consumeResult("throughput-metric", std::to_string(throughputMetric), unit);
+      consumer.consumeResult("throughput", std::to_string(throughput), unit + "/s");
+    } else {
+      consumer.consumeResult("throughput-metric", "N/A", "");
+      consumer.consumeResult("throughput", "N/A", "");
     }
+  }
+
+private:
+  const BenchmarkArgs args;
+
+  std::chrono::time_point<std::chrono::high_resolution_clock> t1;
+  std::chrono::time_point<std::chrono::high_resolution_clock> t2;
+
+  std::vector<double> seconds;
 };


### PR DESCRIPTION
This adds the ability for benchmarks to provide a `getThroughputMetric` function, which returns a metric (e.g. GiB) that can be used to compute throughput (e.g. GiB/s), as well as its unit string. The framework then computes the maximum throughput using the minimum running time measured.

Additionally change the "comment" field of `ResultConsumer::consumeResult` to be a "unit" instead, as that is the only thing we use it for.