### PR TITLE
Add experimental support for LLVM SYCL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ include_directories(${CMAKE_SOURCE_DIR}/polybench/common)
 set(supported_implementations
   ComputeCpp
   hipSYCL
+  LLVM
+  LLVM-CUDA
   triSYCL
 )
 
@@ -39,6 +41,11 @@ if(SYCL_IMPL STREQUAL "ComputeCpp")
   find_package(ComputeCpp MODULE REQUIRED)
 elseif(SYCL_IMPL STREQUAL "hipSYCL")
   find_package(hipSYCL CONFIG REQUIRED)
+elseif(SYCL_IMPL STREQUAL "LLVM")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl")
+elseif(SYCL_IMPL STREQUAL "LLVM-CUDA")
+  set(CMAKE_CXX_FLAGS
+    "${CMAKE_CXX_FLAGS} -fsycl -fsycl-targets=nvptx64-nvidia-cuda-sycldevice")
 elseif(SYCL_IMPL STREQUAL "triSYCL")
   find_package(TriSYCL MODULE REQUIRED)
 endif()
@@ -87,10 +94,22 @@ foreach(benchmark IN LISTS benchmarks)
   get_filename_component(target ${benchmark} NAME_WE)
 
   add_executable(${target} ${benchmark})
+
+  if(SYCL_IMPL STREQUAL "ComputeCpp" OR SYCL_IMPL STREQUAL "hipSYCL")
+    add_sycl_to_target(TARGET ${target} SOURCES ${benchmark})
+  endif()
+
+  if(SYCL_IMPL STREQUAL "LLVM")
+    target_compile_definitions(${target} PRIVATE __LLVM_SYCL__)
+  endif()
+
+  if(SYCL_IMPL STREQUAL "LLVM-CUDA")
+    target_compile_definitions(${target} PRIVATE __LLVM_SYCL_CUDA__)
+  endif()
+
   if(SYCL_IMPL STREQUAL "triSYCL")
     add_sycl_to_target(${target})
-  else()
-    add_sycl_to_target(TARGET ${target} SOURCES ${benchmark})
+    target_compile_definitions(${target} PRIVATE __TRISYCL__)
   endif()
 
   install(TARGETS ${target} RUNTIME DESTINATION bin/benchmarks/)

--- a/include/command_line.h
+++ b/include/command_line.h
@@ -152,8 +152,8 @@ private:
 struct VerificationSetting
 {
   bool enabled;
-  cl::sycl::id<3> begin;
-  cl::sycl::range<3> range;
+  cl::sycl::id<3> begin = {0, 0, 0};
+  cl::sycl::range<3> range = {1, 1, 1};
 };
 
 struct BenchmarkArgs
@@ -166,6 +166,18 @@ struct BenchmarkArgs
   // can be used to query additional benchmark specific information from the command line
   CommandLine cli;
   std::shared_ptr<ResultConsumer> result_consumer;
+};
+
+class CUDASelector : public cl::sycl::device_selector {
+public:
+  int operator()(const cl::sycl::device& device) const override {
+    using namespace cl::sycl::info;
+    const std::string driverVersion = device.get_info<device::driver_version>();
+    if(device.is_gpu() && (driverVersion.find("CUDA") != std::string::npos)) {
+      return 1;
+    };
+    return -1;
+  }
 };
 
 class BenchmarkCommandLine
@@ -210,6 +222,7 @@ public:
 
 private:
   std::shared_ptr<ResultConsumer>
+
   getResultConsumer(const std::string& result_consumer_name) const
   {
     if(result_consumer_name == "stdio")
@@ -220,15 +233,19 @@ private:
       return std::shared_ptr<ResultConsumer>{new AppendingCsvResultConsumer{result_consumer_name}};
   }
 
-  cl::sycl::queue getQueue(const std::string& device_selector) const
-  {
-    if (device_selector == "cpu") {
-      cl::sycl::cpu_selector selector;
-      return selector.select_device();
+  cl::sycl::queue getQueue(const std::string& device_selector) const {
+#if defined(__LLVM_SYCL_CUDA__)
+    if(device_selector != "gpu") {
+      throw std::invalid_argument{"Only the 'gpu' device is supported on LLVM CUDA"};
+    }
+    return cl::sycl::queue{CUDASelector{}};
+#endif
+
+    if(device_selector == "cpu") {
+      return cl::sycl::queue{cl::sycl::cpu_selector{}};
     }
     else if(device_selector == "gpu") {
-      cl::sycl::gpu_selector selector;
-      return selector.select_device();
+      return cl::sycl::queue{cl::sycl::gpu_selector{}};
     }
     else if(device_selector == "default") {
       return cl::sycl::queue{};

--- a/include/common.h
+++ b/include/common.h
@@ -114,15 +114,19 @@ private:
   BenchmarkArgs args;  
   std::vector<BenchmarkHook*> hooks;
 
-  std::string getSyclImplementation() const
-  {
+  std::string getSyclImplementation() const {
 #if defined(__HIPSYCL__)
     return "hipSYCL";
 #elif defined(__COMPUTECPP__)
     return "ComputeCpp";
+#elif defined(__LLVM_SYCL__)
+    return "LLVM (Intel DPC++)";
+#elif defined(__LLVM_SYCL_CUDA__)
+    return "LLVM CUDA (Codeplay)";
+#elif defined(__TRISYCL__)
+    return "triSYCL";
 #else
-    // ToDo: Find out how they can be distinguished
-    return "triSYCL or Intel SYCL";
+    return "UNKNOWN";
 #endif
   }
 };

--- a/micro/DRAM.cpp
+++ b/micro/DRAM.cpp
@@ -19,7 +19,6 @@ s::range<Dims> getBufferSize(size_t problemSize) {
   if constexpr(Dims == 3) {
     return s::range<3>(problemSize / sizeof(DataT), problemSize, problemSize);
   }
-  return {};
 }
 
 /**


### PR DESCRIPTION
This adds experimental support for the "LLVM" and "LLVM-CUDA" SYCL implementations,  corresponding to Intel's DPC++ and Codeplay's fork for targeting CUDA, respectively.

The SYCL compiler needs to be specified using CMAKE_CXX_COMPILER.