### PR TITLE
Initial implementation of prefetched buffer, convert DRAM and pattern_arith to use it

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -18,10 +18,13 @@
 #include "benchmark_hook.h"
 #include "benchmark_traits.h"
 #include "time_meas.h"
+#include "prefetched_buffer.h"
 
 #ifdef NV_ENERGY_MEAS    
   #include "nv_energy_meas.h"
 #endif
+
+
 
 template<class Benchmark>
 class BenchmarkManager

--- a/include/prefetched_buffer.h
+++ b/include/prefetched_buffer.h
@@ -1,0 +1,74 @@
+#pragma once 
+#include <CL/sycl.hpp>
+#include <memory>
+
+class InitializationDummyKernel;
+
+template<class BufferType>
+inline void forceDataTransfer(cl::sycl::queue& q, BufferType b)
+{
+  q.submit([&](cl::sycl::handler& cgh){
+    auto acc = b.template get_access<cl::sycl::access::mode::read>(cgh);
+    cgh.single_task<InitializationDummyKernel>([=](){});
+  });
+  q.wait_and_throw();
+}
+
+template<class T, int Dimensions>
+class PrefetchedBuffer
+{
+public:
+  void initialize(cl::sycl::queue& q, cl::sycl::range<Dimensions> r)
+  {
+    buff = std::make_shared<cl::sycl::buffer<T,Dimensions>>(r);
+  }
+
+  void initialize(cl::sycl::queue& q, T* data, cl::sycl::range<Dimensions> r)
+  {
+    buff = std::make_shared<cl::sycl::buffer<T,Dimensions>>(data, r);
+    forceDataTransfer(q, *buff);
+  }
+
+  void initialize(cl::sycl::queue& q, const T* data, cl::sycl::range<Dimensions> r)
+  {
+    buff = std::make_shared<cl::sycl::buffer<T,Dimensions>>(data, r);
+    forceDataTransfer(q, *buff);
+  }
+
+
+  template <cl::sycl::access::mode mode, 
+            cl::sycl::access::target target = cl::sycl::access::target::global_buffer>
+  auto get_access(cl::sycl::handler &commandGroupHandler)
+  {
+    return buff->template get_access<mode, target>(commandGroupHandler);
+  }
+
+  template <cl::sycl::access::mode mode>
+  auto get_access()
+  {
+    return buff->template get_access<mode>();
+  }
+
+  template <cl::sycl::access::mode mode, 
+            cl::sycl::access::target target = cl::sycl::access::target::global_buffer>
+  auto get_access(
+      cl::sycl::handler &commandGroupHandler, cl::sycl::range<Dimensions> accessRange,
+      cl::sycl::id<Dimensions> accessOffset = {})
+  {
+    return buff->template get_access<mode, target>(commandGroupHandler, accessRange, accessOffset);
+  }
+
+  template <cl::sycl::access::mode mode>
+  auto get_access(
+      cl::sycl::range<Dimensions> accessRange, cl::sycl::id<Dimensions> accessOffset = {})
+  {
+    return buff->template get_access<mode>(accessRange, accessOffset);
+  }
+
+  cl::sycl::buffer<T, Dimensions>& get() const
+  { return *buff; }
+
+private:
+  // Wrap in a shared_ptr to allow default constructing this class
+  std::shared_ptr<cl::sycl::buffer<T, Dimensions>> buff;
+};

--- a/include/prefetched_buffer.h
+++ b/include/prefetched_buffer.h
@@ -1,72 +1,58 @@
-#pragma once 
+#pragma once
 #include <CL/sycl.hpp>
 #include <memory>
 
 class InitializationDummyKernel;
 
-template<class BufferType>
-inline void forceDataTransfer(cl::sycl::queue& q, BufferType b)
-{
-  q.submit([&](cl::sycl::handler& cgh){
+template <class BufferType>
+inline void forceDataTransfer(cl::sycl::queue& q, BufferType b) {
+  q.submit([&](cl::sycl::handler& cgh) {
     auto acc = b.template get_access<cl::sycl::access::mode::read>(cgh);
-    cgh.single_task<InitializationDummyKernel>([=](){});
+    cgh.single_task<InitializationDummyKernel>([=]() {});
   });
   q.wait_and_throw();
 }
 
-template<class T, int Dimensions>
-class PrefetchedBuffer
-{
+template <class T, int Dimensions>
+class PrefetchedBuffer {
 public:
-  void initialize(cl::sycl::queue& q, cl::sycl::range<Dimensions> r)
-  {
-    buff = std::make_shared<cl::sycl::buffer<T,Dimensions>>(r);
+  void initialize(cl::sycl::queue& q, cl::sycl::range<Dimensions> r) {
+    buff = std::make_shared<cl::sycl::buffer<T, Dimensions>>(r);
   }
 
-  void initialize(cl::sycl::queue& q, T* data, cl::sycl::range<Dimensions> r)
-  {
-    buff = std::make_shared<cl::sycl::buffer<T,Dimensions>>(data, r);
+  void initialize(cl::sycl::queue& q, T* data, cl::sycl::range<Dimensions> r) {
+    buff = std::make_shared<cl::sycl::buffer<T, Dimensions>>(data, r);
     forceDataTransfer(q, *buff);
   }
 
-  void initialize(cl::sycl::queue& q, const T* data, cl::sycl::range<Dimensions> r)
-  {
-    buff = std::make_shared<cl::sycl::buffer<T,Dimensions>>(data, r);
+  void initialize(cl::sycl::queue& q, const T* data, cl::sycl::range<Dimensions> r) {
+    buff = std::make_shared<cl::sycl::buffer<T, Dimensions>>(data, r);
     forceDataTransfer(q, *buff);
   }
 
 
-  template <cl::sycl::access::mode mode, 
-            cl::sycl::access::target target = cl::sycl::access::target::global_buffer>
-  auto get_access(cl::sycl::handler &commandGroupHandler)
-  {
+  template <cl::sycl::access::mode mode, cl::sycl::access::target target = cl::sycl::access::target::global_buffer>
+  auto get_access(cl::sycl::handler& commandGroupHandler) {
     return buff->template get_access<mode, target>(commandGroupHandler);
   }
 
   template <cl::sycl::access::mode mode>
-  auto get_access()
-  {
+  auto get_access() {
     return buff->template get_access<mode>();
   }
 
-  template <cl::sycl::access::mode mode, 
-            cl::sycl::access::target target = cl::sycl::access::target::global_buffer>
-  auto get_access(
-      cl::sycl::handler &commandGroupHandler, cl::sycl::range<Dimensions> accessRange,
-      cl::sycl::id<Dimensions> accessOffset = {})
-  {
+  template <cl::sycl::access::mode mode, cl::sycl::access::target target = cl::sycl::access::target::global_buffer>
+  auto get_access(cl::sycl::handler& commandGroupHandler, cl::sycl::range<Dimensions> accessRange,
+      cl::sycl::id<Dimensions> accessOffset = {}) {
     return buff->template get_access<mode, target>(commandGroupHandler, accessRange, accessOffset);
   }
 
   template <cl::sycl::access::mode mode>
-  auto get_access(
-      cl::sycl::range<Dimensions> accessRange, cl::sycl::id<Dimensions> accessOffset = {})
-  {
+  auto get_access(cl::sycl::range<Dimensions> accessRange, cl::sycl::id<Dimensions> accessOffset = {}) {
     return buff->template get_access<mode>(accessRange, accessOffset);
   }
 
-  cl::sycl::buffer<T, Dimensions>& get() const
-  { return *buff; }
+  cl::sycl::buffer<T, Dimensions>& get() const { return *buff; }
 
 private:
   // Wrap in a shared_ptr to allow default constructing this class

--- a/micro/DRAM.cpp
+++ b/micro/DRAM.cpp
@@ -33,15 +33,15 @@ protected:
   // we have to keep this around, unfortunately.
   std::vector<DataT> input;
   PrefetchedBuffer<DataT, Dims> input_buf;
-  s::buffer<DataT, Dims> output_buf;
+  PrefetchedBuffer<DataT, Dims> output_buf;
 
 public:
   MicroBenchDRAM(const BenchmarkArgs& args)
-      : args(args), buffer_size(getBufferSize<DataT, Dims>(args.problem_size)), input(buffer_size.size(), 33.f),
-        output_buf(buffer_size) {}
+      : args(args), buffer_size(getBufferSize<DataT, Dims>(args.problem_size)), input(buffer_size.size(), 33.f) {}
 
   void setup() {
     input_buf.initialize(args.device_queue, input.data(), buffer_size);
+    output_buf.initialize(args.device_queue, buffer_size);
   }
 
   static ThroughputMetric getThroughputMetric(const BenchmarkArgs& args) {

--- a/micro/pattern_L2.cpp
+++ b/micro/pattern_L2.cpp
@@ -12,21 +12,22 @@ class MicroBenchL2
 {
 protected:
     std::vector<DATA_TYPE> input;
-    std::vector<DATA_TYPE> output;
     BenchmarkArgs args;
 
+    PrefetchedBuffer<DATA_TYPE, 1> input_buf;
+    PrefetchedBuffer<DATA_TYPE, 1> output_buf;
 public:
   MicroBenchL2(const BenchmarkArgs &_args) : args(_args) {}
 
   void setup() {
     // buffers initialized to a default value 
     input. resize(args.problem_size, 10);
-    output.resize(args.problem_size, 42);
+
+    input_buf.initialize(args.device_queue, input.data(), s::range<1>(args.problem_size));
+    output_buf.initialize(args.device_queue, s::range<1>(args.problem_size));
   }
 
   void run(){
-    s::buffer<DATA_TYPE, 1>  input_buf (input.data(), s::range<1>(args.problem_size));
-    s::buffer<DATA_TYPE, 1> output_buf(output.data(), s::range<1>(args.problem_size));
 
     args.device_queue.submit(
         [&](cl::sycl::handler& cgh) {
@@ -45,7 +46,6 @@ public:
         out[gid] = r0;
       });
     }); // submit
-    args.device_queue.wait_and_throw();
   }
 
   static std::string getBenchmarkName() {

--- a/micro/pattern_arith.cpp
+++ b/micro/pattern_arith.cpp
@@ -15,7 +15,8 @@ protected:
     std::vector<DATA_TYPE> output;
     BenchmarkArgs args;
 
-    PrefetchedBuffer<DATA_TYPE, 1>  input_buf;
+    PrefetchedBuffer<DATA_TYPE, 1> input_buf;
+    PrefetchedBuffer<DATA_TYPE, 1> output_buf;
 public:
   MicroBenchArithmetic(const BenchmarkArgs &_args) 
   : args(_args){}
@@ -26,10 +27,10 @@ public:
     output.resize(args.problem_size, 42);
 
     input_buf.initialize(args.device_queue, input.data(), s::range<1>(args.problem_size));
+    output_buf.initialize(args.device_queue, output.data(), s::range<1>(args.problem_size));
   }
 
   void run(){
-    s::buffer<DATA_TYPE, 1> output_buf(output.data(), s::range<1>(args.problem_size));
 
     args.device_queue.submit(
         [&](cl::sycl::handler& cgh) {
@@ -52,7 +53,6 @@ public:
         out[gid] = r0;
       });  
     }); // submit
-    args.device_queue.wait_and_throw();
   }
 
   static std::string getBenchmarkName() {

--- a/micro/pattern_arith.cpp
+++ b/micro/pattern_arith.cpp
@@ -15,17 +15,20 @@ protected:
     std::vector<DATA_TYPE> output;
     BenchmarkArgs args;
 
+    PrefetchedBuffer<DATA_TYPE, 1>  input_buf;
 public:
-  MicroBenchArithmetic(const BenchmarkArgs &_args) : args(_args) {}
+  MicroBenchArithmetic(const BenchmarkArgs &_args) 
+  : args(_args){}
   
   void setup() {     
     // buffers initialized to a default value 
     input. resize(args.problem_size, 10);
     output.resize(args.problem_size, 42);
+
+    input_buf.initialize(args.device_queue, input.data(), s::range<1>(args.problem_size));
   }
 
   void run(){
-    s::buffer<DATA_TYPE, 1>  input_buf (input.data(), s::range<1>(args.problem_size));
     s::buffer<DATA_TYPE, 1> output_buf(output.data(), s::range<1>(args.problem_size));
 
     args.device_queue.submit(

--- a/micro/pattern_sf.cpp
+++ b/micro/pattern_sf.cpp
@@ -15,6 +15,8 @@ protected:
     std::vector<DATA_TYPE> output;
     BenchmarkArgs args;
 
+    PrefetchedBuffer<DATA_TYPE, 1> input_buf;
+    PrefetchedBuffer<DATA_TYPE, 1> output_buf;
 public:
   MicroBenchSpecialFunc(const BenchmarkArgs &_args) : args(_args) {}
 
@@ -22,11 +24,12 @@ public:
     // buffers initialized to a default value
     input. resize(args.problem_size, 10);
     output.resize(args.problem_size, 42);
+
+    input_buf.initialize(args.device_queue, input.data(), s::range<1>(args.problem_size));
+    output_buf.initialize(args.device_queue, output.data(), s::range<1>(args.problem_size));
   }
 
   void run(){
-    s::buffer<DATA_TYPE, 1>  input_buf (input.data(), s::range<1>(args.problem_size));
-    s::buffer<DATA_TYPE, 1> output_buf(output.data(), s::range<1>(args.problem_size));
 
     args.device_queue.submit(
         [&](cl::sycl::handler& cgh) {
@@ -49,7 +52,6 @@ public:
         out[gid] = r0;
       });
     }); // submit
-    args.device_queue.wait_and_throw();
   }
 
   static std::string getBenchmarkName() {

--- a/micro/pattern_shared.cpp
+++ b/micro/pattern_shared.cpp
@@ -15,6 +15,8 @@ protected:
     std::vector<DATA_TYPE> output;
     BenchmarkArgs args;
 
+    PrefetchedBuffer<DATA_TYPE, 1> input_buf;
+    PrefetchedBuffer<DATA_TYPE, 1> output_buf;
 public:
   MicroBenchLocalMemory(const BenchmarkArgs &_args) : args(_args) {}
 
@@ -22,12 +24,12 @@ public:
     // buffers initialized to a default value
     input. resize(args.problem_size, 10); 
     output.resize(args.problem_size, 42); 
+
+    input_buf.initialize(args.device_queue, input.data(), s::range<1>(args.problem_size));
+    output_buf.initialize(args.device_queue, output.data(), s::range<1>(args.problem_size));
   }
 
   void run(){
-    s::buffer<DATA_TYPE, 1>  input_buf (input.data(), s::range<1>(args.problem_size));
-    s::buffer<DATA_TYPE, 1> output_buf(output.data(), s::range<1>(args.problem_size));
-
     args.device_queue.submit(
         [&](cl::sycl::handler& cgh) {
       auto in  =  input_buf.template get_access<s::access::mode::read>(cgh);
@@ -50,7 +52,6 @@ public:
         }
       });
     }); // submit
-    args.device_queue.wait_and_throw();
   }
 
   static std::string getBenchmarkName() {

--- a/pattern/reduction.cpp
+++ b/pattern/reduction.cpp
@@ -17,14 +17,14 @@ class Reduction
 protected:
     std::vector<T> _input;
     BenchmarkArgs _args;
-    sycl::buffer<T, 1> _input_buff;
-    sycl::buffer<T, 1> _output_buff;
+
+    PrefetchedBuffer<T, 1> _input_buff;
+    PrefetchedBuffer<T, 1> _output_buff;
+    sycl::buffer<T, 1>* _final_output_buff;
     T _result;
 public:
     Reduction(const BenchmarkArgs &args)
-      : _args{args}, 
-        _input_buff{sycl::range<1>{1}}, // buffer can't be default constructed
-        _output_buff{sycl::range<1>{args.problem_size}}
+      : _args{args}
   {  
     assert(_args.problem_size % _args.local_size == 0);
   }
@@ -38,8 +38,9 @@ public:
 
   void setup() {
     generate_input(_input);
-    _input_buff = sycl::buffer<T, 1>{static_cast<const T *>(_input.data()),
-                                     sycl::range<1>(_args.problem_size)};
+
+    _input_buff.initialize(_args.device_queue, static_cast<const T*>(_input.data()), sycl::range<1>(_args.problem_size));
+    _output_buff.initialize(_args.device_queue, sycl::range<1>{_args.problem_size});
   }
 
 
@@ -59,14 +60,17 @@ public:
   }
 
   bool verify(VerificationSetting &ver) {
-    return _result == std::accumulate(_input.begin(), _input.end(), T{});
+    T result = _final_output_buff->template get_access<sycl::access::mode::read>(
+        sycl::range<1>{0}, sycl::id<1>{1})[0];
+    
+    return result == std::accumulate(_input.begin(), _input.end(), T{});
   }
 private:
   template<class Kernel_invocation_function>
   void submit(Kernel_invocation_function kernel)
   {
-    sycl::buffer<T, 1>* input_buff = &_input_buff;
-    sycl::buffer<T, 1>* output_buff = &_output_buff;
+    sycl::buffer<T, 1>* input_buff = &_input_buff.get();
+    sycl::buffer<T, 1>* output_buff = &_output_buff.get();
 
     size_t current_reduction_size = _args.problem_size;
     size_t current_num_groups = _args.problem_size / _args.local_size;
@@ -90,10 +94,7 @@ private:
 
     } while(current_num_groups > 0);
     
-    // Retrieve result
-    using namespace cl::sycl::access;
-    _result = output_buff->template get_access<mode::read>(
-        sycl::range<1>{0}, sycl::id<1>{1})[0];
+    _final_output_buff = output_buff;
   }
 
   void local_reduce_ndrange(

--- a/pattern/segmentedreduction.cpp
+++ b/pattern/segmentedreduction.cpp
@@ -16,11 +16,10 @@ class SegmentedReduction
 protected:
     std::vector<T> _input;
     BenchmarkArgs _args;
-    sycl::buffer<T, 1> _buff;
+    PrefetchedBuffer<T, 1> _buff;
 public:
   SegmentedReduction(const BenchmarkArgs &args)
-      : _args{args}, 
-        _buff{sycl::range<1>{1}} // buffer can't be default constructed
+      : _args{args}
   {
     
     assert(_args.problem_size % _args.local_size == 0);
@@ -35,7 +34,7 @@ public:
 
   void setup() {
     generate_input(_input);
-    _buff = sycl::buffer<T, 1>{_input.data(), sycl::range<1>(_args.problem_size)};
+    _buff.initialize(_args.device_queue,_input.data(), sycl::range<1>(_args.problem_size));
   }
 
   void submit_ndrange(){

--- a/polybench/2DConvolution.cpp
+++ b/polybench/2DConvolution.cpp
@@ -49,13 +49,13 @@ class Polybench_2DConvolution {
 		B.resize(size * size);
 
 		init(A.data(), size);
+
+		A_buffer.initialize(args.device_queue, A.data(), cl::sycl::range<2>(size, size));
+		B_buffer.initialize(args.device_queue, B.data(), cl::sycl::range<2>(size, size));
 	}
 
 	void run() {
 		using namespace cl::sycl;
-
-		buffer<DATA_TYPE, 2> A_buffer(A.data(), range<2>(size, size));
-		buffer<DATA_TYPE, 2> B_buffer(B.data(), range<2>(size, size));
 
 		args.device_queue.submit([&](handler& cgh) {
 			auto A = A_buffer.get_access<access::mode::read>(cgh);
@@ -81,13 +81,15 @@ class Polybench_2DConvolution {
 	bool verify(VerificationSetting&) {
 		constexpr auto ERROR_THRESHOLD = 0.05;
 
+		auto B_acc = B_buffer.get_access<cl::sycl::access::mode::read>();
+
 		std::vector<DATA_TYPE> B_cpu(size * size);
 		conv2D(A.data(), B_cpu.data(), size);
 
 		for(size_t i = 0; i < size; i++) {
 			for(size_t j = 0; j < size; j++) {
 				if((i > 0) && (j > 0) && (i < size - 1) && (j < size - 1)) {
-					const auto diff = percentDiff(B_cpu[i * size + j], B[i * size + j]);
+					const auto diff = percentDiff(B_cpu[i * size + j], B_acc.get_pointer()[i * size + j]);
 					if(diff > ERROR_THRESHOLD) return false;
 				}
 			}
@@ -104,6 +106,9 @@ class Polybench_2DConvolution {
 	const size_t size;
 	std::vector<DATA_TYPE> A;
 	std::vector<DATA_TYPE> B;
+
+	PrefetchedBuffer<DATA_TYPE, 2> A_buffer;
+	PrefetchedBuffer<DATA_TYPE, 2> B_buffer;
 };
 
 int main(int argc, char** argv) {

--- a/polybench/3DConvolution.cpp
+++ b/polybench/3DConvolution.cpp
@@ -60,13 +60,13 @@ class Polybench_3DConvolution {
 		B.resize(size * size * size);
 
 		init(A.data(), size);
+
+		A_buffer.initialize(args.device_queue, A.data(), cl::sycl::range<3>(size, size, size));
+		B_buffer.initialize(args.device_queue, B.data(), cl::sycl::range<3>(size, size, size));
 	}
 
 	void run() {
 		using namespace cl::sycl;
-
-		buffer<DATA_TYPE, 3> A_buffer(A.data(), range<3>(size, size, size));
-		buffer<DATA_TYPE, 3> B_buffer(B.data(), range<3>(size, size, size));
 
 		args.device_queue.submit([&](handler& cgh) {
 			auto A = A_buffer.get_access<access::mode::read>(cgh);
@@ -99,12 +99,16 @@ class Polybench_3DConvolution {
 		std::vector<DATA_TYPE> B_cpu(size * size * size);
 		conv3D(A.data(), B_cpu.data(), size);
 
+		auto B_acc = B_buffer.get_access<cl::sycl::access::mode::read>();
+
 		for(size_t i = 0; i < size; i++) {
 			for(size_t j = 0; j < size; j++) {
 				for(size_t k = 0; k < size; k++) {
 					if((i > 0) && (j > 0) && (k > 0) && (i < (size - 1)) && (j < (size - 1)) && (k < (size - 1))) {
-						const auto diff = percentDiff(B_cpu[i * (size * size) + j * size + k], B[i * (size * size) + j * size + k]);
-						if(diff > ERROR_THRESHOLD) return false;
+						const auto diff = percentDiff(B_cpu[i * (size * size) + j * size + k],
+								B_acc.get_pointer()[i * (size * size) + j * size + k]);
+						if(diff > ERROR_THRESHOLD)
+							return false;
 					}
 				}
 			}
@@ -121,6 +125,9 @@ class Polybench_3DConvolution {
 	const size_t size;
 	std::vector<DATA_TYPE> A;
 	std::vector<DATA_TYPE> B;
+
+	PrefetchedBuffer<DATA_TYPE, 3> A_buffer;
+	PrefetchedBuffer<DATA_TYPE, 3> B_buffer;
 };
 
 int main(int argc, char** argv) {

--- a/polybench/3mm.cpp
+++ b/polybench/3mm.cpp
@@ -98,18 +98,18 @@ class Polybench_3mm {
 		G.resize(size * size);
 
 		init_array(A.data(), B.data(), C.data(), D.data(), size);
+
+		A_buffer.initialize(args.device_queue, A.data(), cl::sycl::range<2>(size, size));
+		B_buffer.initialize(args.device_queue, B.data(), cl::sycl::range<2>(size, size));
+		C_buffer.initialize(args.device_queue, C.data(), cl::sycl::range<2>(size, size));
+		D_buffer.initialize(args.device_queue, D.data(), cl::sycl::range<2>(size, size));
+		E_buffer.initialize(args.device_queue, E.data(), cl::sycl::range<2>(size, size));
+		F_buffer.initialize(args.device_queue, F.data(), cl::sycl::range<2>(size, size));
+		G_buffer.initialize(args.device_queue, G.data(), cl::sycl::range<2>(size, size));
 	}
 
 	void run() {
 		using namespace cl::sycl;
-
-		buffer<DATA_TYPE, 2> A_buffer(A.data(), range<2>(size, size));
-		buffer<DATA_TYPE, 2> B_buffer(B.data(), range<2>(size, size));
-		buffer<DATA_TYPE, 2> C_buffer(C.data(), range<2>(size, size));
-		buffer<DATA_TYPE, 2> D_buffer(D.data(), range<2>(size, size));
-		buffer<DATA_TYPE, 2> E_buffer(E.data(), range<2>(size, size));
-		buffer<DATA_TYPE, 2> F_buffer(F.data(), range<2>(size, size));
-		buffer<DATA_TYPE, 2> G_buffer(G.data(), range<2>(size, size));
 
 		args.device_queue.submit([&](handler& cgh) {
 			auto A = A_buffer.get_access<access::mode::read>(cgh);
@@ -165,11 +165,14 @@ class Polybench_3mm {
 		std::vector<DATA_TYPE> E_cpu(size * size);
 		std::vector<DATA_TYPE> F_cpu(size * size);
 		std::vector<DATA_TYPE> G_cpu(size * size);
+
 		mm3_cpu(A.data(), B.data(), C.data(), D.data(), E_cpu.data(), F_cpu.data(), G_cpu.data(), size);
+
+		auto G_acc = G_buffer.get_access<cl::sycl::access::mode::read>();
 
 		for(size_t i = 0; i < size; i++) {
 			for(size_t j = 0; j < size; j++) {
-				const auto diff = percentDiff(G_cpu[i * size + j], G[i * size + j]);
+				const auto diff = percentDiff(G_cpu[i * size + j], G_acc.get_pointer()[i * size + j]);
 				if(diff > ERROR_THRESHOLD) return false;
 			}
 		}
@@ -190,6 +193,14 @@ class Polybench_3mm {
 	std::vector<DATA_TYPE> E;
 	std::vector<DATA_TYPE> F;
 	std::vector<DATA_TYPE> G;
+
+	PrefetchedBuffer<DATA_TYPE, 2> A_buffer;
+	PrefetchedBuffer<DATA_TYPE, 2> B_buffer;
+	PrefetchedBuffer<DATA_TYPE, 2> C_buffer;
+	PrefetchedBuffer<DATA_TYPE, 2> D_buffer;
+	PrefetchedBuffer<DATA_TYPE, 2> E_buffer;
+	PrefetchedBuffer<DATA_TYPE, 2> F_buffer;
+	PrefetchedBuffer<DATA_TYPE, 2> G_buffer;
 };
 
 int main(int argc, char** argv) {

--- a/polybench/atax.cpp
+++ b/polybench/atax.cpp
@@ -55,15 +55,15 @@ class Polybench_Atax {
 		tmp.resize(size);
 
 		init_array(x.data(), A.data(), size);
+
+		A_buffer.initialize(args.device_queue, A.data(), cl::sycl::range<2>{size, size});
+		x_buffer.initialize(args.device_queue, x.data(), cl::sycl::range<1>{size});
+		y_buffer.initialize(args.device_queue, y.data(), cl::sycl::range<1>{size});
+		tmp_buffer.initialize(args.device_queue, tmp.data(), cl::sycl::range<1>{size});
 	}
 
 	void run() {
 		using namespace cl::sycl;
-
-		buffer<DATA_TYPE, 2> A_buffer{A.data(), range<2>(size, size)};
-		buffer<DATA_TYPE, 1> x_buffer{x.data(), range<1>(size)};
-		buffer<DATA_TYPE, 1> y_buffer{y.data(), range<1>(size)};
-		buffer<DATA_TYPE, 1> tmp_buffer{tmp.data(), range<1>(size)};
 
 		args.device_queue.submit([&](handler& cgh) {
 			auto A = A_buffer.get_access<access::mode::read>(cgh);
@@ -104,8 +104,10 @@ class Polybench_Atax {
 
 		atax_cpu(A.data(), x.data(), y_cpu.data(), tmp_cpu.data(), size);
 
+		auto y_acc = y_buffer.get_access<cl::sycl::access::mode::read>();
+
 		for(size_t i = 0; i < size; i++) {
-			const auto diff = percentDiff(y_cpu[i], y[i]);
+			const auto diff = percentDiff(y_cpu[i], y_acc[i]);
 			if(diff > ERROR_THRESHOLD) return false;
 		}
 
@@ -122,6 +124,11 @@ class Polybench_Atax {
 	std::vector<DATA_TYPE> x;
 	std::vector<DATA_TYPE> y;
 	std::vector<DATA_TYPE> tmp;
+
+	PrefetchedBuffer<DATA_TYPE, 2> A_buffer;
+	PrefetchedBuffer<DATA_TYPE, 1> x_buffer;
+	PrefetchedBuffer<DATA_TYPE, 1> y_buffer;
+	PrefetchedBuffer<DATA_TYPE, 1> tmp_buffer;
 };
 
 int main(int argc, char** argv) {

--- a/polybench/bicg.cpp
+++ b/polybench/bicg.cpp
@@ -58,16 +58,16 @@ class Polybench_Bicg {
 		q.resize(size);
 
 		init_array(A.data(), p.data(), r.data(), size);
+
+		A_buffer.initialize(args.device_queue, A.data(), cl::sycl::range<2>(size, size));
+		r_buffer.initialize(args.device_queue, r.data(), cl::sycl::range<1>(size));
+	  s_buffer.initialize(args.device_queue, s.data(), cl::sycl::range<1>(size));
+		p_buffer.initialize(args.device_queue, p.data(), cl::sycl::range<1>(size));
+		q_buffer.initialize(args.device_queue, q.data(), cl::sycl::range<1>(size));
 	}
 
 	void run() {
 		using namespace cl::sycl;
-
-		buffer<DATA_TYPE, 2> A_buffer{A.data(), range<2>(size, size)};
-		buffer<DATA_TYPE, 1> r_buffer{r.data(), range<1>(size)};
-		buffer<DATA_TYPE, 1> s_buffer{s.data(), range<1>(size)};
-		buffer<DATA_TYPE, 1> p_buffer{p.data(), range<1>(size)};
-		buffer<DATA_TYPE, 1> q_buffer{q.data(), range<1>(size)};
 
 		args.device_queue.submit([&](handler& cgh) {
 			auto A = A_buffer.get_access<access::mode::read>(cgh);
@@ -101,6 +101,10 @@ class Polybench_Bicg {
 	bool verify(VerificationSetting&) {
 		constexpr auto ERROR_THRESHOLD = 0.05;
 
+		// Trigger writebacks
+		s_buffer.reset();
+		q_buffer.reset();
+
 		std::vector<DATA_TYPE> s_cpu(size);
 		std::vector<DATA_TYPE> q_cpu(size);
 
@@ -128,6 +132,12 @@ class Polybench_Bicg {
 	std::vector<DATA_TYPE> s;
 	std::vector<DATA_TYPE> p;
 	std::vector<DATA_TYPE> q;
+
+	PrefetchedBuffer<DATA_TYPE, 2> A_buffer;
+	PrefetchedBuffer<DATA_TYPE, 1> r_buffer;
+	PrefetchedBuffer<DATA_TYPE, 1> s_buffer;
+	PrefetchedBuffer<DATA_TYPE, 1> p_buffer;
+	PrefetchedBuffer<DATA_TYPE, 1> q_buffer;
 };
 
 int main(int argc, char** argv) {

--- a/polybench/covariance.cpp
+++ b/polybench/covariance.cpp
@@ -61,7 +61,7 @@ void covariance(DATA_TYPE* data, DATA_TYPE* symmat, DATA_TYPE* mean, size_t size
 }
 
 class Polybench_Covariance {
-  public:
+public:
 	Polybench_Covariance(const BenchmarkArgs& args) : args(args), size(args.problem_size) {}
 
 	void setup() {
@@ -70,14 +70,14 @@ class Polybench_Covariance {
 		mean.resize(size + 1);
 
 		init_arrays(data.data(), size);
-	}
+
+		data_buffer.initialize(args.device_queue, data.data(), cl::sycl::range<2>(size + 1, size + 1));
+		symmat_buffer.initialize(args.device_queue, symmat.data(), cl::sycl::range<2>(size + 1, size + 1));
+		mean_buffer.initialize(args.device_queue, mean.data(), cl::sycl::range<1>(size + 1));
+  }
 
 	void run() {
 		using namespace cl::sycl;
-
-		buffer<DATA_TYPE, 2> data_buffer{data.data(), range<2>(size + 1, size + 1)};
-		buffer<DATA_TYPE, 2> symmat_buffer{symmat.data(), range<2>(size + 1, size + 1)};
-		buffer<DATA_TYPE, 1> mean_buffer{mean.data(), range<1>(size + 1)};
 
 		args.device_queue.submit([&](handler& cgh) {
 			auto data = data_buffer.get_access<access::mode::read>(cgh);
@@ -133,6 +133,9 @@ class Polybench_Covariance {
 		std::vector<DATA_TYPE> symmat_cpu((size + 1) * (size + 1));
 		std::vector<DATA_TYPE> mean_cpu(size + 1);
 
+		// Trigger writeback
+		symmat_buffer.reset();
+
 		init_arrays(data_cpu.data(), size);
 
 		covariance(data_cpu.data(), symmat_cpu.data(), mean_cpu.data(), size);
@@ -149,13 +152,17 @@ class Polybench_Covariance {
 
 	static std::string getBenchmarkName() { return "Polybench_Covariance"; }
 
-  private:
+private:
 	BenchmarkArgs args;
 
 	const size_t size;
 	std::vector<DATA_TYPE> data;
 	std::vector<DATA_TYPE> symmat;
 	std::vector<DATA_TYPE> mean;
+
+	PrefetchedBuffer<DATA_TYPE, 2> data_buffer;
+	PrefetchedBuffer<DATA_TYPE, 2> symmat_buffer;
+	PrefetchedBuffer<DATA_TYPE, 1> mean_buffer;
 };
 
 int main(int argc, char** argv) {

--- a/polybench/gemm.cpp
+++ b/polybench/gemm.cpp
@@ -65,14 +65,14 @@ class Polybench_Gemm {
 		C.resize(size * size);
 
 		init(A.data(), B.data(), C.data(), size);
+
+		A_buffer.initialize(args.device_queue, A.data(), cl::sycl::range<2>(size, size));
+		B_buffer.initialize(args.device_queue, B.data(), cl::sycl::range<2>(size, size));
+		C_buffer.initialize(args.device_queue, C.data(), cl::sycl::range<2>(size, size));
 	}
 
 	void run() {
 		using namespace cl::sycl;
-
-		buffer<DATA_TYPE, 2> A_buffer{A.data(), range<2>(size, size)};
-		buffer<DATA_TYPE, 2> B_buffer{B.data(), range<2>(size, size)};
-		buffer<DATA_TYPE, 2> C_buffer{C.data(), range<2>(size, size)};
 
 		args.device_queue.submit([&](handler& cgh) {
 			auto A = A_buffer.get_access<access::mode::read>(cgh);
@@ -95,6 +95,9 @@ class Polybench_Gemm {
 	bool verify(VerificationSetting&) {
 		constexpr auto ERROR_THRESHOLD = 0.05;
 
+		// Trigger writeback
+		C_buffer.reset();
+
 		std::vector<DATA_TYPE> C_cpu(size * size);
 
 		init(A.data(), B.data(), C_cpu.data(), size);
@@ -113,13 +116,17 @@ class Polybench_Gemm {
 
 	static std::string getBenchmarkName() { return "Polybench_Gemm"; }
 
-  private:
+private:
 	BenchmarkArgs args;
 
 	const size_t size;
 	std::vector<DATA_TYPE> A;
 	std::vector<DATA_TYPE> B;
 	std::vector<DATA_TYPE> C;
+
+	PrefetchedBuffer<DATA_TYPE, 2> A_buffer;
+	PrefetchedBuffer<DATA_TYPE, 2> B_buffer;
+	PrefetchedBuffer<DATA_TYPE, 2> C_buffer;
 };
 
 int main(int argc, char** argv) {

--- a/polybench/mvt.cpp
+++ b/polybench/mvt.cpp
@@ -56,16 +56,16 @@ class Polybench_Mvt {
 		y2.resize(size);
 
 		init_arrays(a.data(), x1.data(), x2.data(), y1.data(), y2.data(), size);
+
+		a_buffer .initialize(args.device_queue, a.data(), cl::sycl::range<2>(size, size));
+		x1_buffer.initialize(args.device_queue, x1.data(), cl::sycl::range<1>(size));
+		x2_buffer.initialize(args.device_queue, x2.data(), cl::sycl::range<1>(size));
+		y1_buffer.initialize(args.device_queue, y1.data(), cl::sycl::range<1>(size));
+		y2_buffer.initialize(args.device_queue, y2.data(), cl::sycl::range<1>(size));
 	}
 
 	void run() {
 		using namespace cl::sycl;
-
-		buffer<DATA_TYPE, 2> a_buffer(a.data(), range<2>(size, size));
-		buffer<DATA_TYPE, 1> x1_buffer(x1.data(), range<1>(size));
-		buffer<DATA_TYPE, 1> x2_buffer(x2.data(), range<1>(size));
-		buffer<DATA_TYPE, 1> y1_buffer(y1.data(), range<1>(size));
-		buffer<DATA_TYPE, 1> y2_buffer(y2.data(), range<1>(size));
 
 		args.device_queue.submit([&](handler& cgh) {
 			auto a = a_buffer.get_access<access::mode::read>(cgh);
@@ -128,6 +128,12 @@ class Polybench_Mvt {
 	std::vector<DATA_TYPE> x2;
 	std::vector<DATA_TYPE> y1;
 	std::vector<DATA_TYPE> y2;
+
+	PrefetchedBuffer<DATA_TYPE, 2> a_buffer;
+	PrefetchedBuffer<DATA_TYPE, 1> x1_buffer;
+	PrefetchedBuffer<DATA_TYPE, 1> x2_buffer;
+	PrefetchedBuffer<DATA_TYPE, 1> y1_buffer;
+	PrefetchedBuffer<DATA_TYPE, 1> y2_buffer;
 };
 
 int main(int argc, char** argv) {

--- a/polybench/syr2k.cpp
+++ b/polybench/syr2k.cpp
@@ -61,14 +61,14 @@ class Polybench_Syr2k {
 		C.resize(size * size);
 
 		init_arrays(A.data(), B.data(), C.data(), size);
+
+		A_buffer.initialize(args.device_queue, A.data(), cl::sycl::range<2>(size, size));
+		B_buffer.initialize(args.device_queue, B.data(), cl::sycl::range<2>(size, size));
+		C_buffer.initialize(args.device_queue, C.data(), cl::sycl::range<2>(size, size));
 	}
 
 	void run() {
 		using namespace cl::sycl;
-
-		buffer<DATA_TYPE, 2> A_buffer{A.data(), range<2>(size, size)};
-		buffer<DATA_TYPE, 2> B_buffer{B.data(), range<2>(size, size)};
-		buffer<DATA_TYPE, 2> C_buffer{C.data(), range<2>(size, size)};
 
 		args.device_queue.submit([&](handler& cgh) {
 			auto A = A_buffer.get_access<access::mode::read>(cgh);
@@ -95,6 +95,9 @@ class Polybench_Syr2k {
 
 		init_arrays(A.data(), B.data(), C_cpu.data(), size);
 
+		// Trigger writeback
+		C_buffer.reset();
+
 		syr2k(A.data(), B.data(), C_cpu.data(), size);
 
 		for(size_t i = 0; i < size; i++) {
@@ -116,6 +119,10 @@ class Polybench_Syr2k {
 	std::vector<DATA_TYPE> A;
 	std::vector<DATA_TYPE> B;
 	std::vector<DATA_TYPE> C;
+
+	PrefetchedBuffer<DATA_TYPE, 2> A_buffer;
+	PrefetchedBuffer<DATA_TYPE, 2> B_buffer;
+	PrefetchedBuffer<DATA_TYPE, 2> C_buffer;
 };
 
 int main(int argc, char** argv) {

--- a/runtime/dag_task_throughput_independent.cpp
+++ b/runtime/dag_task_throughput_independent.cpp
@@ -26,6 +26,7 @@ public:
   {
     for (std::size_t i = 0; i < args.problem_size; ++i) {
       dummy_buffers.push_back(sycl::buffer<int, 1>{sycl::range<1>{1}});
+      forceDataAllocation(args.device_queue, dummy_buffers.back());
     }
   }
 

--- a/runtime/dag_task_throughput_sequential.cpp
+++ b/runtime/dag_task_throughput_sequential.cpp
@@ -16,18 +16,15 @@ class DagTaskThroughputKernelHierarchicalPF;
 // * other overheads
 class DagTaskThroughput
 {
-  sycl::buffer<int, 1> dummy_counter;
+  const int initial_value;
+  PrefetchedBuffer<int, 1> dummy_counter;
   BenchmarkArgs args;
 public:
   DagTaskThroughput(const BenchmarkArgs &_args) 
-  : args(_args), dummy_counter{sycl::range<1>{1}}
+  : initial_value{0}, args(_args)
   {}
-  
-  void setup() 
-  {
-    const int initial_value = 0;
-    dummy_counter = sycl::buffer<int, 1>{&initial_value, sycl::range<1>{1}};
-  }
+
+  void setup() { dummy_counter.initialize(args.device_queue, &initial_value, sycl::range<1>{1}); }
 
   void submit_single_task()
   {

--- a/runtime/matmulchain.cpp
+++ b/runtime/matmulchain.cpp
@@ -6,25 +6,27 @@
 // Performs chained matrix multiply of the form (AB)(CD)
 // Uses two intermediate buffers and one for the result
 
-template <typename T> class MatmulChain;
+template <typename T>
+class MatmulChain;
 
 template <typename T>
-void multiply(cl::sycl::queue &queue, cl::sycl::buffer<T, 2> &mat_a, cl::sycl::buffer<T, 2> &mat_b, cl::sycl::buffer<T, 2> &mat_c, const size_t mat_size) {
-        queue.submit([&](cl::sycl::handler& cgh) {
-                auto a = mat_a.template get_access<cl::sycl::access::mode::read>(cgh);
-                auto b = mat_b.template get_access<cl::sycl::access::mode::read>(cgh);
-                auto c = mat_c.template get_access<cl::sycl::access::mode::discard_write>(cgh);
+void multiply(cl::sycl::queue& queue, cl::sycl::buffer<T, 2>& mat_a, cl::sycl::buffer<T, 2>& mat_b,
+    cl::sycl::buffer<T, 2>& mat_c, const size_t mat_size) {
+  queue.submit([&](cl::sycl::handler& cgh) {
+    auto a = mat_a.template get_access<cl::sycl::access::mode::read>(cgh);
+    auto b = mat_b.template get_access<cl::sycl::access::mode::read>(cgh);
+    auto c = mat_c.template get_access<cl::sycl::access::mode::discard_write>(cgh);
 
-                cgh.parallel_for<class MatmulChain<T>>(cl::sycl::range<2>(mat_size, mat_size), [=](cl::sycl::item<2> item) {
-                        auto sum = 0;
-                        for(size_t k = 0; k < mat_size; ++k) {
-                                const auto a_ik = a[{item[0], k}];
-                                const auto b_kj = b[{k, item[1]}];
-                                sum += a_ik * b_kj;
-                        }
-                        c[item] = sum;
-                });
-        });
+		cgh.parallel_for<class MatmulChain<T>>(cl::sycl::range<2>(mat_size, mat_size), [=](cl::sycl::item<2> item) {
+			auto sum = 0;
+			for(size_t k = 0; k < mat_size; ++k) {
+				const auto a_ik = a[{item[0], k}];
+				const auto b_kj = b[{k, item[1]}];
+				sum += a_ik * b_kj;
+			}
+			c[item] = sum;
+		});
+  });
 }
 
 
@@ -39,6 +41,14 @@ protected:
 	BenchmarkArgs args;
 	int mat_size;
 
+	PrefetchedBuffer<T, 2> mat_a_buf;
+  PrefetchedBuffer<T, 2> mat_b_buf;
+  PrefetchedBuffer<T, 2> mat_c_buf;
+  PrefetchedBuffer<T, 2> mat_d_buf;
+  PrefetchedBuffer<T, 2> mat_res_buf;
+  PrefetchedBuffer<T, 2> mat_p_buf;
+  PrefetchedBuffer<T, 2> mat_q_buf;
+
 public:
 	MatmulChain(const BenchmarkArgs &_args) : args(_args) {
 		mat_size = args.problem_size;
@@ -51,36 +61,36 @@ public:
 		mat_d = std::vector<T>(mat_size * mat_size);
 		mat_res = std::vector<T>(mat_size * mat_size);
 
-        	// Initialize matrices to the identity
-        	for(size_t i = 0; i < mat_size; ++i) {
-        	        for(size_t j = 0; j < mat_size; ++j) {
-        	                mat_a[i * mat_size + j] = i == j;
-        	                mat_b[i * mat_size + j] = i == j;
-        	                mat_c[i * mat_size + j] = i == j;
-        	                mat_d[i * mat_size + j] = i == j;
-        	        }
-        	}
+		// Initialize matrices to the identity
+		for(size_t i = 0; i < mat_size; ++i) {
+			for(size_t j = 0; j < mat_size; ++j) {
+				mat_a[i * mat_size + j] = i == j;
+				mat_b[i * mat_size + j] = i == j;
+				mat_c[i * mat_size + j] = i == j;
+				mat_d[i * mat_size + j] = i == j;
+			}
+		}
+
+		mat_a_buf.initialize(args.device_queue, mat_a.data(), cl::sycl::range<2>(mat_size, mat_size));
+		mat_b_buf.initialize(args.device_queue, mat_b.data(), cl::sycl::range<2>(mat_size, mat_size));
+		mat_c_buf.initialize(args.device_queue, mat_c.data(), cl::sycl::range<2>(mat_size, mat_size));
+		mat_d_buf.initialize(args.device_queue, mat_d.data(), cl::sycl::range<2>(mat_size, mat_size));
+		mat_res_buf.initialize(args.device_queue, mat_res.data(), cl::sycl::range<2>(mat_size, mat_size));
+		mat_p_buf.initialize(args.device_queue, cl::sycl::range<2>(mat_size, mat_size));
+		mat_q_buf.initialize(args.device_queue, cl::sycl::range<2>(mat_size, mat_size));
 	}
 
 	void run() {
-		cl::sycl::buffer<T, 2> mat_a_buf(mat_a.data(), cl::sycl::range<2>(mat_size, mat_size));
-                cl::sycl::buffer<T, 2> mat_b_buf(mat_b.data(), cl::sycl::range<2>(mat_size, mat_size));
-                cl::sycl::buffer<T, 2> mat_c_buf(mat_c.data(), cl::sycl::range<2>(mat_size, mat_size));
-                cl::sycl::buffer<T, 2> mat_d_buf(mat_d.data(), cl::sycl::range<2>(mat_size, mat_size));
-                cl::sycl::buffer<T, 2> mat_res_buf(mat_res.data(), cl::sycl::range<2>(mat_size, mat_size));
-                cl::sycl::buffer<T, 2> mat_p_buf(cl::sycl::range<2>(mat_size, mat_size));
-                cl::sycl::buffer<T, 2> mat_q_buf(cl::sycl::range<2>(mat_size, mat_size));
-
-		multiply(args.device_queue, mat_a_buf, mat_b_buf, mat_p_buf, mat_size);
-                multiply(args.device_queue, mat_c_buf, mat_d_buf, mat_q_buf, mat_size);
-                multiply(args.device_queue, mat_p_buf, mat_q_buf, mat_res_buf, mat_size);
+		multiply(args.device_queue, mat_a_buf.get(), mat_b_buf.get(), mat_p_buf.get(), mat_size);
+		multiply(args.device_queue, mat_c_buf.get(), mat_d_buf.get(), mat_q_buf.get(), mat_size);
+		multiply(args.device_queue, mat_p_buf.get(), mat_q_buf.get(), mat_res_buf.get(), mat_size);
 	}
 
-	static std::string getBenchmarkName() {
-		return "MatmulChain";
-	}
+  static std::string getBenchmarkName() { return "MatmulChain"; }
 
-	bool verify(VerificationSetting &ver) {
+  bool verify(VerificationSetting &ver) {
+		// Triggers writeback
+		mat_res_buf.reset();
 		bool verification_passed = true;
 
 		for(size_t i = 0; i < mat_size; ++i) {

--- a/single-kernel/median.cpp
+++ b/single-kernel/median.cpp
@@ -32,6 +32,9 @@ protected:
     size_t size; // user-defined size (input and output will be size x size)
     BenchmarkArgs args;
 
+    PrefetchedBuffer<cl::sycl::float4, 2>  input_buf;    
+    PrefetchedBuffer<cl::sycl::float4, 2> output_buf;
+
 public:
   MedianFilterBench(const BenchmarkArgs &_args) : args(_args) {}
 
@@ -40,11 +43,12 @@ public:
     input.resize(size * size); 
     load_bitmap_mirrored("../../share/Brommy.bmp", size, input);
     output.resize(size * size);
+
+    input_buf.initialize(args.device_queue, input.data(), s::range<2>(size, size));    
+    output_buf.initialize(args.device_queue, output.data(), s::range<2>(size, size));
   }
 
   void run() {    
-    s::buffer<cl::sycl::float4, 2>  input_buf( input.data(), s::range<2>(size, size));    
-    s::buffer<cl::sycl::float4, 2> output_buf(output.data(), s::range<2>(size, size));
 
     args.device_queue.submit(
         [&](cl::sycl::handler& cgh) {
@@ -124,6 +128,8 @@ public:
     save_bitmap("median.bmp", size, output);
 
     bool pass = true;
+    auto output_acc = output_buf.get_access<s::access::mode::read>();
+
     for(size_t i=ver.begin[0]; i<ver.begin[0]+ver.range[0]; i++){
       int x = i % size;
       int y = i / size;
@@ -164,7 +170,7 @@ public:
       swap(window, 3, 5);
       swap(window, 3, 4);
       cl::sycl::float4 expected = window[4];
-      cl::sycl::float4 dif = fdim(output[i], expected);
+      cl::sycl::float4 dif = fdim(output_acc.get_pointer()[i], expected);
       float length = cl::sycl::length(dif);
       if(length > 0.01f)
       {

--- a/single-kernel/sobel.cpp
+++ b/single-kernel/sobel.cpp
@@ -15,13 +15,16 @@ class SobelBenchKernel; // kernel forward declaration
 class SobelBench
 {
 protected:
-    std::vector<cl::sycl::float4> input;
-    std::vector<cl::sycl::float4> output;
+  std::vector<cl::sycl::float4> input;
+  std::vector<cl::sycl::float4> output;
 
-    size_t w, h; // size of the input picture
-    size_t size; // user-defined size (input and output will be size x size)
-    BenchmarkArgs args;
+  size_t w, h; // size of the input picture
+  size_t size; // user-defined size (input and output will be size x size)
+  BenchmarkArgs args;
 
+
+  PrefetchedBuffer<cl::sycl::float4, 2> input_buf;    
+  PrefetchedBuffer<cl::sycl::float4, 2> output_buf;
 public:
   SobelBench(const BenchmarkArgs &_args) : args(_args) {}
 
@@ -30,121 +33,113 @@ public:
     input.resize(size * size); 
     load_bitmap_mirrored("../../share/Brommy.bmp", size, input);
     output.resize(size * size);
+
+    input_buf.initialize(args.device_queue, input.data(), s::range<2>(size, size));    
+    output_buf.initialize(args.device_queue, output.data(), s::range<2>(size, size));
   }
 
-  void run() {    
-    s::buffer<cl::sycl::float4, 2> input_buf( input.data(), s::range<2>(size, size));    
-    s::buffer<cl::sycl::float4, 2> output_buf(output.data(), s::range<2>(size, size));
-
-    args.device_queue.submit(
-        [&](cl::sycl::handler& cgh) {
-      auto in  = input_buf .get_access<s::access::mode::read>(cgh);
+  void run() {
+    args.device_queue.submit([&](cl::sycl::handler& cgh) {
+      auto in = input_buf.get_access<s::access::mode::read>(cgh);
       auto out = output_buf.get_access<s::access::mode::discard_write>(cgh);
-      cl::sycl::range<2> ndrange {size, size};
+      cl::sycl::range<2> ndrange{size, size};
 
       // Sobel kernel 3x3
-      const float kernel[] =
-      { 1, 0, -1,
-        2, 0, -2,
-        1, 0, -1
-      };
+      const float kernel[] = {1, 0, -1, 2, 0, -2, 1, 0, -1};
 
-      cgh.parallel_for<class SobelBenchKernel>(ndrange,
-        [in, out, kernel, size_ = size](cl::sycl::id<2> gid)
-        {
-          int x = gid[0];
-          int y = gid[1];
-          cl::sycl::float4 Gx = cl::sycl::float4(0,0,0,0);
-       	  cl::sycl::float4 Gy = cl::sycl::float4(0,0,0,0);
-          const int radius = 3;
+      cgh.parallel_for<class SobelBenchKernel>(ndrange, [in, out, kernel, size_ = size](cl::sycl::id<2> gid) {
+        int x = gid[0];
+        int y = gid[1];
+        cl::sycl::float4 Gx = cl::sycl::float4(0, 0, 0, 0);
+        cl::sycl::float4 Gy = cl::sycl::float4(0, 0, 0, 0);
+        const int radius = 3;
 
-          // constant-size loops in [0,1,2]
-          for(int x_shift = 0; x_shift<3; x_shift++) 
-          {
-            for(int y_shift = 0; y_shift<3; y_shift++)
-	          {
-              // sample position
-	            uint xs = x + x_shift - 1; // [x-1,x,x+1]
-	            uint ys = y + y_shift - 1; // [y-1,y,y+1]
-              // for the same pixel, convolution is always 0  
-              if(x==xs && y==ys) continue; 
-              // boundary check
-              if(xs < 0 || xs >= size_ || ys < 0 || ys >= size_) continue;
-                    
-	            // sample color
-              cl::sycl::float4 sample = in[ {xs,ys} ];
+        // constant-size loops in [0,1,2]
+        for(int x_shift = 0; x_shift < 3; x_shift++) {
+          for(int y_shift = 0; y_shift < 3; y_shift++) {
+            // sample position
+            uint xs = x + x_shift - 1; // [x-1,x,x+1]
+            uint ys = y + y_shift - 1; // [y-1,y,y+1]
+            // for the same pixel, convolution is always 0
+            if(x == xs && y == ys)
+              continue;
+            // boundary check
+            if(xs < 0 || xs >= size_ || ys < 0 || ys >= size_)
+              continue;
 
-              // convolution calculation
-              int offset_x = x_shift + y_shift * radius;
-              int offset_y = y_shift + x_shift * radius;
-          
-              float conv_x   = kernel[offset_x];
-              cl::sycl::float4 conv4_x = cl::sycl::float4(conv_x);
-              Gx += conv4_x * sample;
+            // sample color
+            cl::sycl::float4 sample = in[{xs, ys}];
 
-              float conv_y   = kernel[offset_y];
-              cl::sycl::float4 conv4_y = cl::sycl::float4(conv_y);
-              Gy += conv4_y * sample;	
-            }
+            // convolution calculation
+            int offset_x = x_shift + y_shift * radius;
+            int offset_y = y_shift + x_shift * radius;
+
+            float conv_x = kernel[offset_x];
+            cl::sycl::float4 conv4_x = cl::sycl::float4(conv_x);
+            Gx += conv4_x * sample;
+
+            float conv_y = kernel[offset_y];
+            cl::sycl::float4 conv4_y = cl::sycl::float4(conv_y);
+            Gy += conv4_y * sample;
           }
-	  // taking root of sums of squares of Gx and Gy 	
-	  cl::sycl::float4 color = hypot(Gx, Gy);
-    cl::sycl::float4 minval = cl::sycl::float4(0.0,0.0,0.0,0.0);
-    cl::sycl::float4 maxval = cl::sycl::float4(1.0,1.0,1.0,1.0);
-	  out[gid] = clamp(color, minval, maxval);
-       }
-       );
-     });
-     
-     args.device_queue.wait_and_throw();
+        }
+        // taking root of sums of squares of Gx and Gy
+        cl::sycl::float4 color = hypot(Gx, Gy);
+        cl::sycl::float4 minval = cl::sycl::float4(0.0, 0.0, 0.0, 0.0);
+        cl::sycl::float4 maxval = cl::sycl::float4(1.0, 1.0, 1.0, 1.0);
+        out[gid] = clamp(color, minval, maxval);
+      });
+    });
    }
 
 
-  bool verify(VerificationSetting &ver) {  
+  bool verify(VerificationSetting& ver) {
+    // Triggers writeback
+    output_buf.reset();
     save_bitmap("sobel3.bmp", size, output);
 
-    const float kernel[] = { 1, 0, -1, 2, 0, -2, 1, 0, -1 };
+    const float kernel[] = {1, 0, -1, 2, 0, -2, 1, 0, -1};
     bool pass = true;
     int radius = 3;
-    for(size_t i=ver.begin[0]; i<ver.begin[0]+ver.range[0]; i++){
+    for(size_t i = ver.begin[0]; i < ver.begin[0] + ver.range[0]; i++) {
       int x = i % size;
       int y = i / size;
-      cl::sycl::float4 Gx, Gy;	
-        for(uint x_shift = 0; x_shift<3; x_shift++)
-             for(uint y_shift = 0; y_shift<3; y_shift++) {
-                  uint xs = x + x_shift - 1;
-                  uint ys = y + y_shift - 1;
-                  if(x==xs && y==ys)  continue;                   
-                  if(xs < 0 || xs >= size || ys < 0 || ys >= size) continue;
-                  cl::sycl::float4 sample = input[xs + ys * size];
-                  int offset_x  = x_shift + y_shift * radius;
-                  int offset_y  = y_shift + x_shift * radius;
-                  float conv_x   = kernel[offset_x];
-                  cl::sycl::float4 conv4_x = cl::sycl::float4(conv_x);
-                  Gx += conv4_x * sample;
-                  float conv_y   = kernel[offset_y];
-                  cl::sycl::float4 conv4_y = cl::sycl::float4(conv_y);
-                  Gy += conv4_y * sample;
-               }
-        cl::sycl::float4 color = hypot(Gx, Gy);
-        cl::sycl::float4 minval = cl::sycl::float4(0.0,0.0,0.0,0.0);
-        cl::sycl::float4 maxval = cl::sycl::float4(1.0,1.0,1.0,1.0);
-        cl::sycl::float4 expected = clamp(color, minval, maxval);
-	      cl::sycl::float4 dif = fdim(output[i], expected);
-        float length = cl::sycl::length(dif);
-        if(length > 0.01f)
-        {
-            pass = false;
-            break;
+      cl::sycl::float4 Gx, Gy;
+      for(uint x_shift = 0; x_shift < 3; x_shift++)
+        for(uint y_shift = 0; y_shift < 3; y_shift++) {
+          uint xs = x + x_shift - 1;
+          uint ys = y + y_shift - 1;
+          if(x == xs && y == ys)
+            continue;
+          if(xs < 0 || xs >= size || ys < 0 || ys >= size)
+            continue;
+          cl::sycl::float4 sample = input[xs + ys * size];
+          int offset_x = x_shift + y_shift * radius;
+          int offset_y = y_shift + x_shift * radius;
+          float conv_x = kernel[offset_x];
+          cl::sycl::float4 conv4_x = cl::sycl::float4(conv_x);
+          Gx += conv4_x * sample;
+          float conv_y = kernel[offset_y];
+          cl::sycl::float4 conv4_y = cl::sycl::float4(conv_y);
+          Gy += conv4_y * sample;
         }
-    }    
+
+      cl::sycl::float4 color = hypot(Gx, Gy);
+      cl::sycl::float4 minval = cl::sycl::float4(0.0, 0.0, 0.0, 0.0);
+      cl::sycl::float4 maxval = cl::sycl::float4(1.0, 1.0, 1.0, 1.0);
+      cl::sycl::float4 expected = clamp(color, minval, maxval);
+      cl::sycl::float4 dif = fdim(output[i], expected);
+      float length = cl::sycl::length(dif);
+      if(length > 0.01f) {
+        pass = false;
+        break;
+      }
+    }
     return pass;
-}
-
-
-static std::string getBenchmarkName() {
-    return "Sobel3";
   }
+
+
+  static std::string getBenchmarkName() { return "Sobel3"; }
 
 }; // SobelBench class
 

--- a/single-kernel/sobel5.cpp
+++ b/single-kernel/sobel5.cpp
@@ -25,6 +25,8 @@ protected:
     size_t size; // user-defined size (input and output will be size x size)
     BenchmarkArgs args;
 
+    PrefetchedBuffer<cl::sycl::float4, 2> input_buf;
+    PrefetchedBuffer<cl::sycl::float4, 2> output_buf;
 public:
   Sobel5Bench(const BenchmarkArgs &_args) : args(_args) {}
 
@@ -33,12 +35,12 @@ public:
     input.resize(size * size);
     load_bitmap_mirrored("../../share/Brommy.bmp", size, input);
     output.resize(size * size);
+
+    input_buf.initialize(args.device_queue, input.data(), s::range<2>(size, size));
+    output_buf.initialize(args.device_queue, output.data(), s::range<2>(size, size));
   }
 
   void run() {
-    s::buffer<cl::sycl::float4, 2> input_buf( input.data(), s::range<2>(size, size));
-    s::buffer<cl::sycl::float4, 2> output_buf(output.data(), s::range<2>(size, size));
-
     args.device_queue.submit(
         [&](cl::sycl::handler& cgh) {
       auto in  = input_buf .get_access<s::access::mode::read>(cgh);
@@ -100,11 +102,11 @@ public:
       }
        );
      });
-
-     args.device_queue.wait_and_throw();
    }
       
   bool verify(VerificationSetting &ver) {
+    // Triggers writeback
+    output_buf.reset();
     save_bitmap("sobel5.bmp", size, output);
 
     const float kernel[] = { 1, 2, 0,  -2, -1,4,  8, 0,  -8, -4, 6, 12, 0, -12, -6, 4,  8, 0,  -8, -4, 1,  2, 0,  -2, -1 };

--- a/single-kernel/sobel7.cpp
+++ b/single-kernel/sobel7.cpp
@@ -23,6 +23,8 @@ protected:
     size_t size; // user-defined size (input and output will be size x size)
     BenchmarkArgs args;
 
+    PrefetchedBuffer<cl::sycl::float4, 2> input_buf;
+    PrefetchedBuffer<cl::sycl::float4, 2> output_buf;
 public:
   Sobel7Bench(const BenchmarkArgs &_args) : args(_args) {}
 
@@ -31,126 +33,119 @@ public:
     input.resize(size * size);
     load_bitmap_mirrored("../../share/Brommy.bmp", size, input);
     output.resize(size * size);
+
+    input_buf.initialize(args.device_queue, input.data(), s::range<2>(size, size));
+    output_buf.initialize(args.device_queue, output.data(), s::range<2>(size, size));
   }
 
   void run() {
-    s::buffer<cl::sycl::float4, 2> input_buf( input.data(), s::range<2>(size, size));
-    s::buffer<cl::sycl::float4, 2> output_buf(output.data(), s::range<2>(size, size));
-
-    args.device_queue.submit(
-        [&](cl::sycl::handler& cgh) {
-      auto in  = input_buf .get_access<s::access::mode::read>(cgh);
+    args.device_queue.submit([&](cl::sycl::handler& cgh) {
+      auto in = input_buf.get_access<s::access::mode::read>(cgh);
       auto out = output_buf.get_access<s::access::mode::discard_write>(cgh);
-      cl::sycl::range<2> ndrange {size, size};
+      cl::sycl::range<2> ndrange{size, size};
 
       // Sobel kernel 7x7
-      const float kernel[] =
-      { 130, 120, 78,  0, -78,  -120, -130,
-        180, 195, 156, 0, -156, -195, -180,
-	      234, 312, 390, 0, -390, -312, -234,
-        260, 390, 780, 0, -780, -390, -260,
-        234, 312, 390, 0, -390, -312, -234,
-	      180, 195, 156, 0, -156, -195, -180,
-	      130, 120, 78,  0, -78,  -120, -130
-      };
+      const float kernel[] = {130, 120, 78, 0, -78, -120, -130, 180, 195, 156, 0, -156, -195, -180, 234, 312, 390, 0,
+          -390, -312, -234, 260, 390, 780, 0, -780, -390, -260, 234, 312, 390, 0, -390, -312, -234, 180, 195, 156, 0,
+          -156, -195, -180, 130, 120, 78, 0, -78, -120, -130};
 
-      cgh.parallel_for<Sobel7BenchKernel>(ndrange,
-        [in, out, kernel, size_ = size](cl::sycl::id<2> gid)
-        {
-          int x = gid[0];
-          int y = gid[1];
-          cl::sycl::float4 Gx = cl::sycl::float4(0,0,0,0);
-          cl::sycl::float4 Gy = cl::sycl::float4(0,0,0,0);
-          const int radius = 7;
+      cgh.parallel_for<Sobel7BenchKernel>(ndrange, [in, out, kernel, size_ = size](cl::sycl::id<2> gid) {
+        int x = gid[0];
+        int y = gid[1];
+        cl::sycl::float4 Gx = cl::sycl::float4(0, 0, 0, 0);
+        cl::sycl::float4 Gy = cl::sycl::float4(0, 0, 0, 0);
+        const int radius = 7;
 
-          // constant-size loops in [0,1,2,3,4,5,6]
-          for(int x_shift = 0; x_shift<7; x_shift++)
-          {
-            for(int y_shift = 0; y_shift<7; y_shift++)
-            {
-              // sample position
-              uint xs = x + x_shift - 3; // [x-3,x-2,x-1,x,x+1,x+2,x+3]
-              uint ys = y + y_shift - 3; // [y-3,y-2,y-1,y,y+1,y+2,y+2]
-              // for the same pixel, convolution is always 0  
-              if(x==xs && y==ys) continue;
-              // boundary check
-              if(xs < 0 || xs >= size_ || ys < 0 || ys >= size_) continue;
+        // constant-size loops in [0,1,2,3,4,5,6]
+        for(int x_shift = 0; x_shift < 7; x_shift++) {
+          for(int y_shift = 0; y_shift < 7; y_shift++) {
+            // sample position
+            uint xs = x + x_shift - 3; // [x-3,x-2,x-1,x,x+1,x+2,x+3]
+            uint ys = y + y_shift - 3; // [y-3,y-2,y-1,y,y+1,y+2,y+2]
+            // for the same pixel, convolution is always 0
+            if(x == xs && y == ys)
+              continue;
+            // boundary check
+            if(xs < 0 || xs >= size_ || ys < 0 || ys >= size_)
+              continue;
 
-              // sample color
-              cl::sycl::float4 sample = in[ {xs,ys} ];
+            // sample color
+            cl::sycl::float4 sample = in[{xs, ys}];
 
-              // convolution calculation
-              int offset_x = x_shift + y_shift * radius;
-              int offset_y = y_shift + x_shift * radius;
+            // convolution calculation
+            int offset_x = x_shift + y_shift * radius;
+            int offset_y = y_shift + x_shift * radius;
 
-              float conv_x   = kernel[offset_x];
-              cl::sycl::float4 conv4_x = cl::sycl::float4(conv_x);
-              Gx += conv4_x * sample;
+            float conv_x = kernel[offset_x];
+            cl::sycl::float4 conv4_x = cl::sycl::float4(conv_x);
+            Gx += conv4_x * sample;
 
-              float conv_y   = kernel[offset_y];
-              cl::sycl::float4 conv4_y = cl::sycl::float4(conv_y);
-              Gy += conv4_y * sample;
-            }
+            float conv_y = kernel[offset_y];
+            cl::sycl::float4 conv4_y = cl::sycl::float4(conv_y);
+            Gy += conv4_y * sample;
           }
-          // taking root of sums of squares of Gx and Gy        
-          cl::sycl::float4 color = hypot(Gx, Gy);
-          cl::sycl::float4 minval = cl::sycl::float4(0.0, 0.0, 0.0, 0.0);
-          cl::sycl::float4 maxval = cl::sycl::float4(1.0, 1.0, 1.0, 1.0);
-          out[gid] = clamp(color, minval, maxval);
-      }
-       );
-     });
-
-     args.device_queue.wait_and_throw();
-   }
-      
-  bool verify(VerificationSetting &ver) {
-    save_bitmap("sobel7.bmp", size, output);
-
-    const float kernel[] = { 130, 120, 78,  0, -78,  -120, -130,
-        180, 195, 156, 0, -156, -195, -180,
-	    234, 312, 390, 0, -390, -312, -234,
-        260, 390, 780, 0, -780, -390, -260,
-        234, 312, 390, 0, -390, -312, -234,
-	    180, 195, 156, 0, -156, -195, -180,
-	    130, 120, 78,  0, -78,  -120, -130 };
-
-    bool pass = true;
-    int radius = 7;
-    for(size_t i=ver.begin[0]; i<ver.begin[0]+ver.range[0]; i++){
-      int x = i % size;
-      int y = i / size;
-      cl::sycl::float4 Gx, Gy;
-        for(uint x_shift = 0; x_shift<7; x_shift++)
-             for(uint y_shift = 0; y_shift<7; y_shift++) {
-                  uint xs = x + x_shift - 3;
-                  uint ys = y + y_shift - 3;
-                  if(x==xs && y==ys)  continue;
-                  if(xs < 0 || xs >= size || ys < 0 || ys >= size) continue;
-                  cl::sycl::float4 sample = input[xs + ys * size];
-                  int offset_x  = x_shift + y_shift * radius;
-                  int offset_y  = y_shift + x_shift * radius;
-                  float conv_x   = kernel[offset_x];
-                  cl::sycl::float4 conv4_x = cl::sycl::float4(conv_x);
-                  Gx += conv4_x * sample;
-                  float conv_y   = kernel[offset_y];
-                  cl::sycl::float4 conv4_y = cl::sycl::float4(conv_y);
-                  Gy += conv4_y * sample;
-               }
+        }
+        // taking root of sums of squares of Gx and Gy
         cl::sycl::float4 color = hypot(Gx, Gy);
         cl::sycl::float4 minval = cl::sycl::float4(0.0, 0.0, 0.0, 0.0);
         cl::sycl::float4 maxval = cl::sycl::float4(1.0, 1.0, 1.0, 1.0);
-        cl::sycl::float4 expected = clamp(color, minval, maxval);
-        cl::sycl::float4 dif = fdim(output[i], expected);
-        float length = cl::sycl::length(dif);
-        if(length > 0.01f)
-        {
-            pass = false;
-            break;
+        out[gid] = clamp(color, minval, maxval);
+      });
+    });
+  }
+
+  bool verify(VerificationSetting& ver) {
+    // Triggers writeback
+    output_buf.reset();
+    save_bitmap("sobel7.bmp", size, output);
+
+    const float kernel[] = {
+      130, 120, 78,  0, -78,  -120, -130,
+      180, 195, 156, 0, -156, -195, -180,
+      234, 312, 390, 0, -390, -312, -234,
+      260, 390, 780, 0, -780, -390, -260,
+      234, 312, 390, 0, -390, -312, -234,
+      180, 195, 156, 0, -156, -195, -180,
+      130, 120, 78,  0, -78,  -120, -130
+    };
+
+    bool pass = true;
+    int radius = 7;
+    for(size_t i = ver.begin[0]; i < ver.begin[0] + ver.range[0]; i++) {
+      int x = i % size;
+      int y = i / size;
+      cl::sycl::float4 Gx, Gy;
+      for(uint x_shift = 0; x_shift < 7; x_shift++)
+        for(uint y_shift = 0; y_shift < 7; y_shift++) {
+          uint xs = x + x_shift - 3;
+          uint ys = y + y_shift - 3;
+          if(x == xs && y == ys)
+            continue;
+          if(xs < 0 || xs >= size || ys < 0 || ys >= size)
+            continue;
+          cl::sycl::float4 sample = input[xs + ys * size];
+          int offset_x = x_shift + y_shift * radius;
+          int offset_y = y_shift + x_shift * radius;
+          float conv_x = kernel[offset_x];
+          cl::sycl::float4 conv4_x = cl::sycl::float4(conv_x);
+          Gx += conv4_x * sample;
+          float conv_y = kernel[offset_y];
+          cl::sycl::float4 conv4_y = cl::sycl::float4(conv_y);
+          Gy += conv4_y * sample;
         }
+      cl::sycl::float4 color = hypot(Gx, Gy);
+      cl::sycl::float4 minval = cl::sycl::float4(0.0, 0.0, 0.0, 0.0);
+      cl::sycl::float4 maxval = cl::sycl::float4(1.0, 1.0, 1.0, 1.0);
+      cl::sycl::float4 expected = clamp(color, minval, maxval);
+      cl::sycl::float4 dif = fdim(output[i], expected);
+      float length = cl::sycl::length(dif);
+      if(length > 0.01f) {
+        pass = false;
+        break;
+      }
     }
     return pass;
-}
+  }
 
 
 static std::string getBenchmarkName() {

--- a/single-kernel/vec_add.cpp
+++ b/single-kernel/vec_add.cpp
@@ -13,16 +13,19 @@ template <typename T>
 class VecAddBench
 {
 protected:    
-    std::vector<T> input1;
-    std::vector<T> input2;
-    std::vector<T> output;
-    BenchmarkArgs args;
+  std::vector<T> input1;
+  std::vector<T> input2;
+  std::vector<T> output;
+  BenchmarkArgs args;
+
+  PrefetchedBuffer<T, 1> input1_buf;
+  PrefetchedBuffer<T, 1> input2_buf;
+  PrefetchedBuffer<T, 1> output_buf;
 
 public:
   VecAddBench(const BenchmarkArgs &_args) : args(_args) {}
   
-  void setup() {      
-
+  void setup() {
     // host memory intilization
     input1.resize(args.problem_size);
     input2.resize(args.problem_size);
@@ -33,13 +36,13 @@ public:
       input2[i] = static_cast<T>(i);
       output[i] = static_cast<T>(0);
     }
+
+    input1_buf.initialize(args.device_queue, input1.data(), s::range<1>(args.problem_size));
+    input2_buf.initialize(args.device_queue, input2.data(), s::range<1>(args.problem_size));
+    output_buf.initialize(args.device_queue, output.data(), s::range<1>(args.problem_size));
   }
 
-  void run() {    
-    s::buffer<T, 1> input1_buf(input1.data(), s::range<1>(args.problem_size));
-    s::buffer<T, 1> input2_buf(input2.data(), s::range<1>(args.problem_size));
-    s::buffer<T, 1> output_buf(output.data(), s::range<1>(args.problem_size));
-
+  void run() {
     args.device_queue.submit(
         [&](cl::sycl::handler& cgh) {
       auto in1 = input1_buf.template get_access<s::access::mode::read>(cgh);
@@ -57,7 +60,10 @@ public:
 
   }
 
-  bool verify(VerificationSetting &ver) { 
+  bool verify(VerificationSetting &ver) {
+    //Triggers writeback
+    output_buf.reset();
+
     bool pass = true;
     for(size_t i=ver.begin[0]; i<ver.begin[0]+ver.range[0]; i++){
         auto expected = input1[i] + input2[i];


### PR DESCRIPTION
Add `PrefetchedBuffer` which is a buffer wrapper to make it easier to make measurements without including data transfers.

I'm still working on converting the entire suite to use it (so far I've only converted DRAM and pattern_arith to use it), so WIP.