### PR TITLE
Make InitializationDummyKernel::operator() const

### DIFF
--- a/include/prefetched_buffer.h
+++ b/include/prefetched_buffer.h
@@ -9,7 +9,7 @@ public:
   InitializationDummyKernel(AccType acc)
   : acc{acc} {}
 
-  void operator()() {}
+  void operator()() const {}
 private:
   AccType acc;
 };


### PR DESCRIPTION
SYCL 2020 does not allow mutable kernels, so InitializationDummyKernel::operator() must be const. Otherwise e.g. DPC++ cannot compile SYCL-Bench.