### PR TITLE
Fix benchmarks write-back

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /build*
 *.csv
 img/
+installed/
 
 # Clangd
 .cache/

--- a/include/bitmap.h
+++ b/include/bitmap.h
@@ -8,8 +8,8 @@
 using std::string;
 
 
-void load_bitmap_mirrored(string filename, int size, std::vector<sycl::float4>& pixels);
-void save_bitmap(string filename, int size, const std::vector<sycl::float4>& buffer);
+void load_bitmap_mirrored(string filename, int size, sycl::float4* input);
+void save_bitmap(string filename, int size, const sycl::float4* output);
 
 /**
   A single Pixel in the image. A Pixel has red, green, and blue
@@ -362,8 +362,7 @@ void load_bitmap_mirrored(string filename, int size, std::vector<sycl::float4>& 
   // std::cout << "[" << w << "x" << h << "] => [" << size << "x" << size << "]" << std::endl;
 }
 
-
-void save_bitmap(string filename, int size, const std::vector<sycl::float4>& output) {
+void save_bitmap(string filename, int size, sycl::float4* output) {
   // write the output picture
   // std::cout << "saving the output picture in " << filename << std::endl;
   Bitmap output_image;

--- a/polybench/bicg.cpp
+++ b/polybench/bicg.cpp
@@ -102,8 +102,8 @@ public:
     constexpr auto ERROR_THRESHOLD = 0.05;
 
     // Trigger writebacks
-    s_buffer.reset();
-    q_buffer.reset();
+    auto s = s_buffer.get_host_access();
+    auto q = q_buffer.get_host_access();
 
     std::vector<DATA_TYPE> s_cpu(size);
     std::vector<DATA_TYPE> q_cpu(size);

--- a/polybench/correlation.cpp
+++ b/polybench/correlation.cpp
@@ -201,7 +201,7 @@ public:
     std::vector<DATA_TYPE> symmat_cpu((size + 1) * (size + 1));
 
     // Trigger writeback
-    symmat_buffer.reset();
+    auto* symmat = symmat_buffer.get_host_access().get_pointer();
 
     init_arrays(data_cpu.data(), size);
     correlation(data_cpu.data(), mean_cpu.data(), stddev_cpu.data(), symmat_cpu.data(), size);

--- a/polybench/covariance.cpp
+++ b/polybench/covariance.cpp
@@ -137,7 +137,7 @@ public:
     std::vector<DATA_TYPE> mean_cpu(size + 1);
 
     // Trigger writeback
-    symmat_buffer.reset();
+    auto* symmat = symmat_buffer.get_host_access().get_pointer();
 
     init_arrays(data_cpu.data(), size);
 

--- a/polybench/fdtd2d.cpp
+++ b/polybench/fdtd2d.cpp
@@ -142,7 +142,7 @@ public:
     std::vector<DATA_TYPE> hz_cpu(size * size);
 
     // Trigger writebacks
-    hz_buffer.reset();
+    auto* hz = hz_buffer.get_host_access().get_pointer();
 
     init_arrays(fict_cpu.data(), ex_cpu.data(), ey_cpu.data(), hz_cpu.data(), size);
 

--- a/polybench/gemm.cpp
+++ b/polybench/gemm.cpp
@@ -96,7 +96,7 @@ public:
     constexpr auto ERROR_THRESHOLD = 0.05;
 
     // Trigger writeback
-    C_buffer.reset();
+    auto* C = C_buffer.get_host_access().get_pointer();
 
     std::vector<DATA_TYPE> C_cpu(size * size);
 

--- a/polybench/gesummv.cpp
+++ b/polybench/gesummv.cpp
@@ -102,7 +102,7 @@ public:
     constexpr auto ERROR_THRESHOLD = 0.05;
 
     // Trigger writeback
-    y_buffer.reset();
+    auto y = y_buffer.get_host_access();
 
     std::vector<DATA_TYPE> y_cpu(size);
     std::vector<DATA_TYPE> tmp_cpu(size);

--- a/polybench/gramschmidt.cpp
+++ b/polybench/gramschmidt.cpp
@@ -129,7 +129,7 @@ public:
     std::vector<DATA_TYPE> Q_cpu(size * size);
 
     // Trigger writeback
-    A_buffer.reset();
+    auto* A = A_buffer.get_host_access().get_pointer();
 
     init_array(A_cpu.data(), size);
 

--- a/polybench/mvt.cpp
+++ b/polybench/mvt.cpp
@@ -103,8 +103,8 @@ public:
     std::vector<DATA_TYPE> x2_cpu(size);
 
     // Trigger writeback
-    x1_buffer.reset();
-    x2_buffer.reset();
+    auto x1 = x1_buffer.get_host_access();
+    auto x2 = x2_buffer.get_host_access();
 
     init_arrays(a.data(), x1_cpu.data(), x2_cpu.data(), y1.data(), y2.data(), size);
 

--- a/polybench/syr2k.cpp
+++ b/polybench/syr2k.cpp
@@ -96,7 +96,7 @@ public:
     init_arrays(A.data(), B.data(), C_cpu.data(), size);
 
     // Trigger writeback
-    C_buffer.reset();
+    auto* C = C_buffer.get_host_access().get_pointer();
 
     syr2k(A.data(), B.data(), C_cpu.data(), size);
 

--- a/polybench/syrk.cpp
+++ b/polybench/syrk.cpp
@@ -88,7 +88,7 @@ public:
     constexpr auto ERROR_THRESHOLD = 0.05;
 
     // Trigger writeback
-    C_buffer.reset();
+    auto* C = C_buffer.get_host_access().get_pointer();
 
     std::vector<DATA_TYPE> C_cpu(size * size);
 

--- a/runtime/matmulchain.cpp
+++ b/runtime/matmulchain.cpp
@@ -88,7 +88,7 @@ public:
 
   bool verify(VerificationSetting& ver) {
     // Triggers writeback
-    mat_res_buf.reset();
+    auto* mat_res = mat_res_buf.get_host_access().get_pointer();
     bool verification_passed = true;
 
     for(size_t i = 0; i < mat_size; ++i) {

--- a/single-kernel/median.cpp
+++ b/single-kernel/median.cpp
@@ -120,10 +120,10 @@ public:
 
 
   bool verify(VerificationSetting& ver) {
-    save_bitmap("median.bmp", size, output);
-
+    
     bool pass = true;
     auto output_acc = output_buf.get_host_access();
+    save_bitmap("median.bmp", size, output_acc.get_pointer());
 
     for(size_t i = ver.begin[0]; i < ver.begin[0] + ver.range[0]; i++) {
       int x = i % size;

--- a/single-kernel/sobel.cpp
+++ b/single-kernel/sobel.cpp
@@ -31,7 +31,7 @@ public:
   void setup() {
     size = args.problem_size; // input size defined by the user
     input.resize(size * size);
-    load_bitmap_mirrored("../../share/Brommy.bmp", size, input);
+    load_bitmap_mirrored("../share/Brommy.bmp", size, input);
     output.resize(size * size);
 
     input_buf.initialize(args.device_queue, input.data(), s::range<2>(size, size));
@@ -95,7 +95,7 @@ public:
 
   bool verify(VerificationSetting& ver) {
     // Triggers writeback
-    output_buf.reset();
+    auto output = output_buf.get_host_access().get_pointer();
     save_bitmap("sobel3.bmp", size, output);
 
     const float kernel[] = {1, 0, -1, 2, 0, -2, 1, 0, -1};

--- a/single-kernel/sobel5.cpp
+++ b/single-kernel/sobel5.cpp
@@ -96,7 +96,7 @@ public:
 
   bool verify(VerificationSetting& ver) {
     // Triggers writeback
-    output_buf.reset();
+    auto* output = output_buf.get_host_access().get_pointer();
     save_bitmap("sobel5.bmp", size, output);
 
     const float kernel[] = {1, 2, 0, -2, -1, 4, 8, 0, -8, -4, 6, 12, 0, -12, -6, 4, 8, 0, -8, -4, 1, 2, 0, -2, -1};

--- a/single-kernel/sobel7.cpp
+++ b/single-kernel/sobel7.cpp
@@ -96,7 +96,7 @@ public:
 
   bool verify(VerificationSetting& ver) {
     // Triggers writeback
-    output_buf.reset();
+    auto* output = output_buf.get_host_access().get_pointer();
     save_bitmap("sobel7.bmp", size, output);
 
     const float kernel[] = {130, 120, 78, 0, -78, -120, -130, 180, 195, 156, 0, -156, -195, -180, 234, 312, 390, 0,

--- a/single-kernel/vec_add.cpp
+++ b/single-kernel/vec_add.cpp
@@ -56,7 +56,7 @@ public:
 
   bool verify(VerificationSetting& ver) {
     // Triggers writeback
-    output_buf.reset();
+    auto output = output_buf.get_host_access();
 
     bool pass = true;
     for(size_t i = ver.begin[0]; i < ver.begin[0] + ver.range[0]; i++) {


### PR DESCRIPTION
In most of the benchmarks using `PrefetchedBuffer`, the write back was not done correctly which was leading to failing verifications. 
This PR fixes that by using `host_accessor`s to correctly get updated values on the host.